### PR TITLE
fix(n0m10s): modal de términos no visible por defecto en móvil

### DIFF
--- a/n0m10s/index.html
+++ b/n0m10s/index.html
@@ -368,7 +368,8 @@
 				overflow-wrap: anywhere;
 			}
 			#terminal-input { min-width: 0; }
-			#terms-modal { padding: 16px; display: flex; }
+			/* No display:flex aquí: el # vence a .modal-overlay y dejaba el modal siempre visible en móvil */
+			#terms-modal { padding: 16px; }
 			#terms-modal > div { max-width: calc(100vw - 32px); padding: 20px; }
 		}
 		@media (max-width: 360px) {


### PR DESCRIPTION
## Problema
En pantallas ≤480px, `#terms-modal { display: flex }` en el media query tenía mayor especificidad que `.modal-overlay { display: none }`, así que el modal de términos aparecía al cargar la página en el celular.

## Solución
Se mantiene solo el `padding` móvil en `#terms-modal`; la visibilidad sigue controlada por el estilo inline del script al abrir/cerrar.

Rama: `develop` → `main`.

Made with [Cursor](https://cursor.com)