### PR TITLE
feat: presentación en vivo MDUFC (setlist + operador PHP)

### DIFF
--- a/presentacion-album-mdufc/.gitignore
+++ b/presentacion-album-mdufc/.gitignore
@@ -1,0 +1,1 @@
+includes/config.php

--- a/presentacion-album-mdufc/APPLY_WORKFLOWS.md
+++ b/presentacion-album-mdufc/APPLY_WORKFLOWS.md
@@ -1,0 +1,13 @@
+# Aplicar cambios en los workflows de deploy (secreto GitHub → `config.php`)
+
+El push automático desde algunos entornos **no puede** modificar `.github/workflows/` sin permiso `workflow`. Este repo incluye un parche para aplicar en tu máquina **antes** de mergear o en un commit aparte:
+
+```bash
+cd /ruta/al/repo
+git apply presentacion-album-mdufc/apply-workflows.patch
+git add .github/workflows/
+git commit -m "ci: generar config.php MDUFC desde secreto en deploy"
+git push
+```
+
+O abrí `apply-workflows.patch` y copiá los cambios a mano en los dos YAML.

--- a/presentacion-album-mdufc/README.md
+++ b/presentacion-album-mdufc/README.md
@@ -1,0 +1,61 @@
+# Presentación MDUFC (en vivo)
+
+Mini sitio para el público: **listado de temas** con desbloqueo según el avance del show, **letra** y **de qué habla** cada canción. Vista **operador** para avanzar o retroceder el índice en el servidor.
+
+Estética alineada con [`n0m10s/`](../n0m10s/).
+
+## URLs
+
+- **Público (QR):** `…/presentacion-album-mdufc/` o `index.html`
+- **Operador (no compartir en QR):** `operator.html`
+
+## Contenido
+
+Editá `data/setlist.json` antes del show: `meta` (título, subtítulo, línea de evento) y el array `songs` con `id`, `title`, `about`, `lyrics`.
+
+El estado en vivo es solo el entero **`currentIndex`** (0 = primer tema). Se guarda en `data/state.json` vía PHP.
+
+## Secreto del operador (`config.php`)
+
+`api/set.php` solo acepta peticiones si el cuerpo incluye el mismo valor que `OPERATOR_SECRET` en `includes/config.php`.
+
+### Opción recomendada: secreto de GitHub
+
+1. En el repo: **Settings → Secrets and variables → Actions → New repository secret**.
+2. Nombre: **`PRESENTACION_MDUFC_OPERATOR_SECRET`** · Valor: una cadena larga y aleatoria (la usás también al operar desde `operator.html`).
+3. En cada deploy, el workflow genera **`includes/config.php`** en el runner (con PHP `var_export`, sin commitear) y lo sube por SFTP con el resto del sitio.
+
+Así no hace falta crear `config.php` a mano en el servidor ni volver a subirlo tras cada deploy.
+
+Si el secreto **no** está definido, el workflow muestra un *warning* y no genera el archivo: podés seguir la opción manual abajo.
+
+### Opción manual (FTP)
+
+1. Copiá `includes/config.example.php` a **`includes/config.php`** en el servidor (no subas `config.php` al repo: está en `.gitignore`).
+2. Definí `OPERATOR_SECRET` con una cadena larga y única (no dejes el placeholder del example).
+
+## Permisos
+
+El usuario de PHP del hosting debe poder **escribir** `data/state.json`. Si falla `set.php` con error `write_failed`, revisá permisos de la carpeta `data/` (p. ej. 0755 o 0775 según el host).
+
+## Bloqueo de `state.json` (opcional)
+
+En `data/.htaccess` se niega el acceso HTTP directo a `state.json`. Si tu host no usa Apache o da error 500, eliminá ese archivo o adaptá la regla.
+
+## CI/CD (igual que el resto del sitio)
+
+Los workflows en `.github/workflows/` hacen **mirror SFTP de todo el repositorio** al hacer push a `develop` o `main`. Esta carpeta se publica **automáticamente** como el resto del sitio (misma mecánica que `n0m10s/`). Un PR no despliega hasta merge y push.
+
+## Desarrollo local sin PHP
+
+Podés probar la UI con **`?dev=1`** en la URL del público y del operador:
+
+- `index.html?dev=1` — el índice se guarda en `localStorage` en ese navegador.
+- `operator.html?dev=1` — los botones actualizan el mismo `localStorage` (sin `config.php`).
+
+## Checklist pre-show
+
+- [ ] `setlist.json` completo y revisado.
+- [ ] Secreto **`PRESENTACION_MDUFC_OPERATOR_SECRET`** en GitHub (o `config.php` manual en el servidor).
+- [ ] Probar `api/state.php` y `api/set.php` desde el móvil con datos (4G/WiFi).
+- [ ] Operador con la URL guardada; público con QR a `index.html`.

--- a/presentacion-album-mdufc/README.md
+++ b/presentacion-album-mdufc/README.md
@@ -23,7 +23,7 @@ El estado en vivo es solo el entero **`currentIndex`** (0 = primer tema). Se gua
 
 1. En el repo: **Settings → Secrets and variables → Actions → New repository secret**.
 2. Nombre: **`PRESENTACION_MDUFC_OPERATOR_SECRET`** · Valor: una cadena larga y aleatoria (la usás también al operar desde `operator.html`).
-3. En cada deploy, el workflow genera **`includes/config.php`** en el runner (con PHP `var_export`, sin commitear) y lo sube por SFTP con el resto del sitio.
+3. Los workflows de deploy deben incluir el paso que genera **`includes/config.php`** antes del mirror SFTP. Si tu repo aún no tiene ese cambio en `.github/workflows/`, aplicá el parche: ver **[`APPLY_WORKFLOWS.md`](APPLY_WORKFLOWS.md)**.
 
 Así no hace falta crear `config.php` a mano en el servidor ni volver a subirlo tras cada deploy.
 

--- a/presentacion-album-mdufc/api/set.php
+++ b/presentacion-album-mdufc/api/set.php
@@ -1,0 +1,98 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	http_response_code(405);
+	echo json_encode(array('ok' => false, 'error' => 'method_not_allowed'));
+	exit;
+}
+
+$root = dirname(__DIR__);
+$configPath = $root . '/includes/config.php';
+
+if (!is_readable($configPath)) {
+	http_response_code(503);
+	echo json_encode(array('ok' => false, 'error' => 'config_missing'));
+	exit;
+}
+
+require $configPath;
+
+if (!defined('OPERATOR_SECRET') || OPERATOR_SECRET === '' || OPERATOR_SECRET === 'reemplazar-por-secreto-largo-y-unico') {
+	http_response_code(503);
+	echo json_encode(array('ok' => false, 'error' => 'config_invalid'));
+	exit;
+}
+
+$rawInput = file_get_contents('php://input');
+$input = json_decode($rawInput, true);
+if (!is_array($input)) {
+	$input = $_POST;
+}
+
+$secret = isset($input['secret']) ? (string) $input['secret'] : '';
+$action = isset($input['action']) ? (string) $input['action'] : '';
+
+if (!hash_equals(OPERATOR_SECRET, $secret)) {
+	http_response_code(403);
+	echo json_encode(array('ok' => false, 'error' => 'forbidden'));
+	exit;
+}
+
+$setlistPath = $root . '/data/setlist.json';
+if (!is_readable($setlistPath)) {
+	http_response_code(500);
+	echo json_encode(array('ok' => false, 'error' => 'setlist_missing'));
+	exit;
+}
+
+$setlist = json_decode(file_get_contents($setlistPath), true);
+$songs = isset($setlist['songs']) && is_array($setlist['songs']) ? $setlist['songs'] : array();
+$max = max(0, count($songs) - 1);
+
+$statePath = $root . '/data/state.json';
+$state = array('currentIndex' => 0, 'updatedAt' => 0);
+if (is_readable($statePath)) {
+	$prev = json_decode(file_get_contents($statePath), true);
+	if (is_array($prev)) {
+		$state = array_merge($state, $prev);
+	}
+}
+
+$idx = isset($state['currentIndex']) ? (int) $state['currentIndex'] : 0;
+$idx = max(0, min($max, $idx));
+
+switch ($action) {
+	case 'next':
+		$idx = min($max, $idx + 1);
+		break;
+	case 'prev':
+		$idx = max(0, $idx - 1);
+		break;
+	case 'reset':
+		$idx = 0;
+		break;
+	default:
+		http_response_code(400);
+		echo json_encode(array('ok' => false, 'error' => 'bad_action'));
+		exit;
+}
+
+$newState = array(
+	'currentIndex' => $idx,
+	'updatedAt' => time(),
+);
+
+$written = @file_put_contents($statePath, json_encode($newState, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . "\n");
+if ($written === false) {
+	http_response_code(500);
+	echo json_encode(array('ok' => false, 'error' => 'write_failed'));
+	exit;
+}
+
+echo json_encode(array(
+	'ok' => true,
+	'currentIndex' => $idx,
+	'updatedAt' => $newState['updatedAt'],
+), JSON_UNESCAPED_UNICODE);

--- a/presentacion-album-mdufc/api/state.php
+++ b/presentacion-album-mdufc/api/state.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+
+$root = dirname(__DIR__);
+$path = $root . '/data/state.json';
+
+if (!is_readable($path)) {
+	echo json_encode(array(
+		'currentIndex' => 0,
+		'updatedAt' => time(),
+	), JSON_UNESCAPED_UNICODE);
+	exit;
+}
+
+$raw = file_get_contents($path);
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+	$data = array();
+}
+
+$idx = isset($data['currentIndex']) ? (int) $data['currentIndex'] : 0;
+$updated = isset($data['updatedAt']) ? (int) $data['updatedAt'] : 0;
+
+echo json_encode(array(
+	'currentIndex' => $idx,
+	'updatedAt' => $updated,
+), JSON_UNESCAPED_UNICODE);

--- a/presentacion-album-mdufc/apply-workflows.patch
+++ b/presentacion-album-mdufc/apply-workflows.patch
@@ -1,0 +1,52 @@
+diff --git a/.github/workflows/deploy-develop-to-stg.yaml b/.github/workflows/deploy-develop-to-stg.yaml
+index 885e002..af24e45 100644
+--- a/.github/workflows/deploy-develop-to-stg.yaml
++++ b/.github/workflows/deploy-develop-to-stg.yaml
+@@ -17,11 +17,19 @@ jobs:
+         SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
+         SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+       run: |
+-        sudo apt-get install lftp
++        sudo apt-get update -qq && sudo apt-get install -y lftp php-cli
+ 
+         git clone -b develop https://github.com/jmalbarra/heo-website-bootstrap.git .
+         cd .
+-        
++
++        # presentacion-album-mdufc: config.php desde secreto (no commiteado)
++        export OPERATOR_SECRET="${{ secrets.PRESENTACION_MDUFC_OPERATOR_SECRET }}"
++        if [ -n "$OPERATOR_SECRET" ]; then
++          php -r '$s=getenv("OPERATOR_SECRET"); $c="<?php\n"."define(\"OPERATOR_SECRET\", ".var_export($s,true).");\n"; file_put_contents("presentacion-album-mdufc/includes/config.php", $c);'
++        else
++          echo "::warning::PRESENTACION_MDUFC_OPERATOR_SECRET no definido; subí includes/config.php a mano o configurá el secreto en el repo."
++        fi
++
+         /usr/bin/lftp -u "$SFTP_USERNAME","$SFTP_PASSWORD" "$SFTP_HOST" << EOF
+         cd htdocs/staging
+         mirror -R . .
+diff --git a/.github/workflows/deploy-main-to-prod.yaml b/.github/workflows/deploy-main-to-prod.yaml
+index 8b254d9..cd1bc83 100644
+--- a/.github/workflows/deploy-main-to-prod.yaml
++++ b/.github/workflows/deploy-main-to-prod.yaml
+@@ -17,11 +17,19 @@ jobs:
+         SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
+         SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+       run: |
+-        sudo apt-get install lftp
++        sudo apt-get update -qq && sudo apt-get install -y lftp php-cli
+ 
+         git clone https://github.com/jmalbarra/heo-website-bootstrap.git .
+         cd .
+-        
++
++        # presentacion-album-mdufc: config.php desde secreto (no commiteado)
++        export OPERATOR_SECRET="${{ secrets.PRESENTACION_MDUFC_OPERATOR_SECRET }}"
++        if [ -n "$OPERATOR_SECRET" ]; then
++          php -r '$s=getenv("OPERATOR_SECRET"); $c="<?php\n"."define(\"OPERATOR_SECRET\", ".var_export($s,true).");\n"; file_put_contents("presentacion-album-mdufc/includes/config.php", $c);'
++        else
++          echo "::warning::PRESENTACION_MDUFC_OPERATOR_SECRET no definido; subí includes/config.php a mano o configurá el secreto en el repo."
++        fi
++
+         /usr/bin/lftp -u "$SFTP_USERNAME","$SFTP_PASSWORD" "$SFTP_HOST" << EOF
+         cd htdocs
+         mirror -R . .

--- a/presentacion-album-mdufc/css/live.css
+++ b/presentacion-album-mdufc/css/live.css
@@ -1,0 +1,382 @@
+/* Tokens alineados con n0m10s/index.html */
+:root {
+	--accent: #22eec9;
+	--accent-dim: rgba(34, 238, 201, 0.5);
+	--accent-glow: rgba(34, 238, 201, 0.4);
+	--accent-bg: rgba(34, 238, 201, 0.12);
+	--surface: rgba(12, 12, 14, 0.9);
+	--surface-border: rgba(34, 238, 201, 0.2);
+	--text: #e8e8e8;
+	--text-muted: rgba(255, 255, 255, 0.4);
+	--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+	--radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+html {
+	-webkit-text-size-adjust: 100%;
+}
+
+body {
+	background: #050507;
+	min-height: 100vh;
+	min-height: 100dvh;
+	font-family: "Geist Mono", "JetBrains Mono", monospace;
+	color: var(--text);
+	line-height: 1.5;
+	overflow-x: hidden;
+}
+
+.font-display {
+	font-family: "Space Grotesk", "Geist Mono", sans-serif;
+}
+
+a {
+	color: var(--accent-dim);
+	text-decoration: none;
+	transition: color 0.2s;
+}
+
+a:hover {
+	color: var(--accent);
+}
+
+code {
+	font-size: 0.85em;
+	color: var(--accent-dim);
+}
+
+.app-wrap {
+	min-height: 100vh;
+	min-height: 100dvh;
+	padding: 24px 20px 48px;
+	max-width: 520px;
+	margin: 0 auto;
+}
+
+.panel {
+	background: var(--surface);
+	backdrop-filter: blur(24px);
+	-webkit-backdrop-filter: blur(24px);
+	border: 1px solid var(--surface-border);
+	border-radius: 12px;
+	box-shadow:
+		0 24px 48px rgba(0, 0, 0, 0.5),
+		0 0 0 1px rgba(255, 255, 255, 0.03),
+		inset 0 1px 0 rgba(255, 255, 255, 0.04);
+	padding: 28px 24px;
+}
+
+.header-block {
+	margin-bottom: 24px;
+	text-align: center;
+}
+
+.header-block .kicker {
+	font-size: 0.7rem;
+	letter-spacing: 0.28em;
+	text-transform: uppercase;
+	color: var(--accent-dim);
+	margin-bottom: 8px;
+}
+
+.header-block h1 {
+	font-family: "Space Grotesk", sans-serif;
+	font-size: 1.35rem;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	color: var(--text);
+	line-height: 1.25;
+}
+
+.header-block .sub {
+	font-size: 0.85rem;
+	color: var(--text-muted);
+	margin-top: 6px;
+}
+
+.btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 14px 28px;
+	font-size: 0.85rem;
+	font-family: inherit;
+	font-weight: 500;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: var(--accent);
+	background: var(--accent-bg);
+	border: 1px solid var(--surface-border);
+	border-radius: var(--radius);
+	cursor: pointer;
+	transition: all 0.4s var(--ease-out);
+	box-shadow: 0 0 0 0 var(--accent-glow);
+}
+
+.btn:hover {
+	background: rgba(34, 238, 201, 0.18);
+	box-shadow: 0 0 32px var(--accent-glow), inset 0 0 20px rgba(34, 238, 201, 0.08);
+	border-color: var(--accent);
+	transform: translateY(-1px);
+}
+
+.btn:active {
+	transform: translateY(0);
+}
+
+.btn-primary-solid {
+	letter-spacing: 0.12em;
+	color: #050507;
+	background: linear-gradient(135deg, var(--accent) 0%, #0d9f82 100%);
+	border: none;
+	box-shadow: 0 4px 16px rgba(34, 238, 201, 0.35);
+}
+
+.btn-primary-solid:hover {
+	box-shadow: 0 8px 28px rgba(34, 238, 201, 0.45), 0 0 0 1px rgba(34, 238, 201, 0.2);
+}
+
+.btn-ghost {
+	background: transparent;
+	letter-spacing: 0.1em;
+}
+
+.input-secret {
+	width: 100%;
+	padding: 14px 18px;
+	font-size: 0.95rem;
+	font-family: inherit;
+	background: rgba(0, 0, 0, 0.35);
+	border: 1px solid var(--surface-border);
+	border-radius: var(--radius);
+	color: var(--accent);
+	outline: none;
+	transition: all 0.3s var(--ease-out);
+}
+
+.input-secret:focus {
+	border-color: var(--accent);
+	box-shadow: 0 0 0 3px var(--accent-bg);
+}
+
+.input-secret::placeholder {
+	color: var(--accent-dim);
+}
+
+.input-secret:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.track-list {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.track-item {
+	display: block;
+	width: 100%;
+	text-align: left;
+	padding: 16px 18px;
+	background: rgba(0, 0, 0, 0.25);
+	border: 1px solid var(--surface-border);
+	border-radius: var(--radius);
+	cursor: pointer;
+	transition: border-color 0.3s var(--ease-out), background 0.3s;
+	color: inherit;
+	font: inherit;
+}
+
+.track-item:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.track-item--past {
+	opacity: 0.85;
+	border-color: rgba(34, 238, 201, 0.12);
+}
+
+.track-item--past .track-title {
+	color: var(--text-muted);
+}
+
+.track-item--current {
+	border-color: var(--accent);
+	background: rgba(34, 238, 201, 0.06);
+	box-shadow: 0 0 24px rgba(34, 238, 201, 0.12);
+}
+
+.track-item--current .track-title {
+	color: var(--accent);
+}
+
+.track-item--locked {
+	cursor: default;
+	opacity: 0.55;
+	border-style: dashed;
+}
+
+.track-item--locked .track-title {
+	color: var(--text-muted);
+	filter: blur(0.35px);
+}
+
+.track-row {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.track-title {
+	font-size: 0.95rem;
+	font-weight: 500;
+	letter-spacing: 0.04em;
+}
+
+.track-badge {
+	font-size: 0.65rem;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--accent-dim);
+	flex-shrink: 0;
+	padding-top: 2px;
+}
+
+.cipher-line {
+	display: block;
+	font-size: 0.68rem;
+	letter-spacing: 0.15em;
+	color: var(--text-muted);
+	margin-top: 8px;
+	opacity: 0.75;
+	font-variant-numeric: tabular-nums;
+	user-select: none;
+}
+
+.detail-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 20px;
+	flex-wrap: wrap;
+}
+
+.detail-header h2 {
+	font-family: "Space Grotesk", sans-serif;
+	font-size: 1.2rem;
+	font-weight: 600;
+	color: var(--accent);
+	flex: 1;
+	min-width: 0;
+}
+
+.section-label {
+	font-size: 0.65rem;
+	letter-spacing: 0.22em;
+	text-transform: uppercase;
+	color: var(--accent-dim);
+	margin-bottom: 8px;
+}
+
+.lyrics-block,
+.about-block {
+	margin-bottom: 22px;
+}
+
+.lyrics-block pre,
+.lyrics-block .lyrics-pre {
+	font-family: inherit;
+	font-size: 0.88rem;
+	line-height: 1.65;
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: var(--text);
+}
+
+.about-block p {
+	font-size: 0.88rem;
+	color: var(--text-muted);
+	line-height: 1.65;
+}
+
+.status-bar {
+	font-size: 0.72rem;
+	color: var(--text-muted);
+	text-align: center;
+	margin-top: 20px;
+	padding-top: 16px;
+	border-top: 1px solid rgba(34, 238, 201, 0.1);
+}
+
+.status-bar--error {
+	color: #f0a0a8;
+}
+
+.operator-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-top: 16px;
+	justify-content: center;
+}
+
+.operator-actions .btn {
+	flex: 1 1 auto;
+	min-width: 120px;
+}
+
+.operator-preview {
+	text-align: center;
+	margin: 20px 0;
+	padding: 16px;
+	background: rgba(0, 0, 0, 0.3);
+	border-radius: var(--radius);
+	border: 1px solid var(--surface-border);
+}
+
+.operator-preview .label {
+	font-size: 0.65rem;
+	letter-spacing: 0.2em;
+	text-transform: uppercase;
+	color: var(--accent-dim);
+	margin-bottom: 6px;
+}
+
+.operator-preview .song-name {
+	font-size: 1rem;
+	color: var(--text);
+}
+
+.hidden {
+	display: none !important;
+}
+
+.dev-banner {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	padding: 8px 12px;
+	font-size: 0.65rem;
+	text-align: center;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	background: rgba(180, 120, 40, 0.25);
+	color: #e8c080;
+	border-top: 1px solid rgba(255, 200, 120, 0.25);
+	z-index: 100;
+}

--- a/presentacion-album-mdufc/data/.htaccess
+++ b/presentacion-album-mdufc/data/.htaccess
@@ -1,0 +1,3 @@
+<Files "state.json">
+	Require all denied
+</Files>

--- a/presentacion-album-mdufc/data/setlist.json
+++ b/presentacion-album-mdufc/data/setlist.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "title": "Presentación MDUFC",
+    "subtitle": "Hacia el Ocaso",
+    "eventLine": "En vivo — setlist"
+  },
+  "songs": [
+    {
+      "id": "ejemplo-1",
+      "title": "Primera luz",
+      "about": "Un tema sobre el instante antes de empezar, cuando el ruido baja y queda solo la expectativa.",
+      "lyrics": "(Letra de ejemplo — reemplazar antes del show.)\n\nVerso uno…\n\nEstribillo…\n\nVerso dos…"
+    },
+    {
+      "id": "ejemplo-2",
+      "title": "Mapa roto",
+      "about": "Sobre perder el rumbo y seguir igual, porque el destino a veces es el camino.",
+      "lyrics": "(Letra de ejemplo.)\n\nBloque A\n\nBloque B"
+    },
+    {
+      "id": "ejemplo-3",
+      "title": "Última llamada",
+      "about": "Cierre del set: todo lo que no se dijo y el eco que queda.",
+      "lyrics": "(Letra de ejemplo.)\n\nFinal…"
+    }
+  ]
+}

--- a/presentacion-album-mdufc/data/state.json
+++ b/presentacion-album-mdufc/data/state.json
@@ -1,0 +1,4 @@
+{
+  "currentIndex": 0,
+  "updatedAt": 0
+}

--- a/presentacion-album-mdufc/includes/config.example.php
+++ b/presentacion-album-mdufc/includes/config.example.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Copiar a config.php en el servidor y definir un secreto largo.
+ * No subir config.php al repositorio público.
+ */
+define('OPERATOR_SECRET', 'reemplazar-por-secreto-largo-y-unico');

--- a/presentacion-album-mdufc/index.html
+++ b/presentacion-album-mdufc/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<title>Presentación MDUFC — Hacia el Ocaso</title>
+	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
+	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+	<link rel="stylesheet" href="css/live.css">
+</head>
+<body>
+	<div class="app-wrap">
+		<div id="view-list">
+			<header class="header-block">
+				<p class="kicker" id="meta-event">En vivo</p>
+				<h1 id="meta-title">…</h1>
+				<p class="sub" id="meta-subtitle"></p>
+			</header>
+			<div class="panel">
+				<ul class="track-list" id="track-list"></ul>
+				<p class="status-bar" id="status-bar"></p>
+			</div>
+		</div>
+
+		<div id="view-detail" class="hidden">
+			<div class="panel">
+				<div class="detail-header">
+					<h2 id="detail-title"></h2>
+					<button type="button" class="btn btn-ghost" id="btn-back">← Volver</button>
+				</div>
+				<div class="about-block">
+					<p class="section-label">De qué habla</p>
+					<p id="about-text"></p>
+				</div>
+				<div class="lyrics-block">
+					<p class="section-label">Letra</p>
+					<pre class="lyrics-pre" id="lyrics-text"></pre>
+				</div>
+			</div>
+		</div>
+	</div>
+	<script src="js/app.js"></script>
+</body>
+</html>

--- a/presentacion-album-mdufc/js/app.js
+++ b/presentacion-album-mdufc/js/app.js
@@ -1,0 +1,279 @@
+(function () {
+	"use strict";
+
+	var POLL_MS = 3000;
+	var STORAGE_DEV = "presentacion_mdufc_dev_index";
+	var API_STATE = "api/state.php";
+
+	var state = {
+		setlist: null,
+		currentIndex: 0,
+		devMode: false,
+		pollTimer: null,
+		cipherTimers: [],
+		lastError: null,
+	};
+
+	function $(sel, root) {
+		return (root || document).querySelector(sel);
+	}
+
+	function isDevMode() {
+		try {
+			var p = new URLSearchParams(window.location.search);
+			if (p.get("dev") === "1") return true;
+		} catch (e) {}
+		return false;
+	}
+
+	function getSongIndexById(id) {
+		if (!state.setlist || !state.setlist.songs) return -1;
+		for (var i = 0; i < state.setlist.songs.length; i++) {
+			if (state.setlist.songs[i].id === id) return i;
+		}
+		return -1;
+	}
+
+	function isUnlocked(songIndex) {
+		return songIndex <= state.currentIndex;
+	}
+
+	function parseHash() {
+		var h = window.location.hash.replace(/^#/, "");
+		if (!h || h === "/" || h === "list") return { view: "list" };
+		var parts = h.split("/");
+		if (parts[0] === "song" && parts[1]) {
+			return { view: "detail", id: decodeURIComponent(parts[1]) };
+		}
+		return { view: "list" };
+	}
+
+	function setHashList() {
+		window.location.hash = "";
+	}
+
+	function setHashSong(id) {
+		window.location.hash = "song/" + encodeURIComponent(id);
+	}
+
+	function randomCipherString(len, seed) {
+		var chars = "Ø01Æ§µ¶†¥₿ΨΩχψ7890";
+		var out = "";
+		var x = seed;
+		for (var i = 0; i < len; i++) {
+			x = (x * 1103515245 + 12345 + i * 17) & 0x7fffffff;
+			out += chars[x % chars.length];
+		}
+		return out;
+	}
+
+	function clearCipherTimers() {
+		state.cipherTimers.forEach(function (id) {
+			clearInterval(id);
+		});
+		state.cipherTimers = [];
+	}
+
+	function attachCipherLines(rootEl) {
+		clearCipherTimers();
+		var lines = rootEl.querySelectorAll("[data-cipher]");
+		lines.forEach(function (el) {
+			var seed = parseInt(el.getAttribute("data-cipher"), 10) || 0;
+			function tick() {
+				el.textContent = randomCipherString(28, seed + Date.now() % 10000);
+			}
+			tick();
+			var id = setInterval(tick, 2200);
+			state.cipherTimers.push(id);
+		});
+	}
+
+	function fetchState() {
+		if (state.devMode) {
+			var raw = localStorage.getItem(STORAGE_DEV);
+			var n = raw === null ? 0 : parseInt(raw, 10);
+			if (isNaN(n)) n = 0;
+			state.currentIndex = n;
+			state.lastError = null;
+			render();
+			return;
+		}
+
+		fetch(API_STATE, { cache: "no-store" })
+			.then(function (r) {
+				if (!r.ok) throw new Error("HTTP " + r.status);
+				return r.json();
+			})
+			.then(function (data) {
+				var idx = parseInt(data.currentIndex, 10);
+				if (isNaN(idx)) idx = 0;
+				state.currentIndex = idx;
+				state.lastError = null;
+				render();
+			})
+			.catch(function () {
+				state.lastError = "No se pudo sincronizar. Reintentando…";
+				render();
+			});
+	}
+
+	function startPolling() {
+		if (state.pollTimer) clearInterval(state.pollTimer);
+		fetchState();
+		if (!state.devMode) {
+			state.pollTimer = setInterval(fetchState, POLL_MS);
+		}
+	}
+
+	function renderList() {
+		var listEl = $("#view-list");
+		var detailEl = $("#view-detail");
+		if (!listEl || !detailEl) return;
+		listEl.classList.remove("hidden");
+		detailEl.classList.add("hidden");
+
+		var meta = state.setlist.meta || {};
+		$("#meta-title").textContent = meta.title || "Setlist";
+		$("#meta-subtitle").textContent = meta.subtitle || "";
+		$("#meta-event").textContent = meta.eventLine || "";
+
+		var ul = $("#track-list");
+		ul.innerHTML = "";
+		var songs = state.setlist.songs || [];
+
+		songs.forEach(function (song, index) {
+			var li = document.createElement("li");
+			var btn = document.createElement("button");
+			btn.type = "button";
+			btn.className = "track-item";
+
+			if (index < state.currentIndex) btn.classList.add("track-item--past");
+			else if (index === state.currentIndex) btn.classList.add("track-item--current");
+			else btn.classList.add("track-item--locked");
+
+			var row = document.createElement("div");
+			row.className = "track-row";
+
+			var title = document.createElement("span");
+			title.className = "track-title";
+			title.textContent = song.title || "Sin título";
+
+			var badge = document.createElement("span");
+			badge.className = "track-badge";
+			if (index < state.currentIndex) badge.textContent = "Listo";
+			else if (index === state.currentIndex) badge.textContent = "Ahora";
+			else badge.textContent = "···";
+
+			row.appendChild(title);
+			row.appendChild(badge);
+			btn.appendChild(row);
+
+			if (index > state.currentIndex) {
+				var cipher = document.createElement("span");
+				cipher.className = "cipher-line";
+				cipher.setAttribute("data-cipher", String(index * 7919 + (song.title || "").length));
+				btn.appendChild(cipher);
+			}
+
+			if (isUnlocked(index)) {
+				btn.addEventListener("click", function () {
+					setHashSong(song.id);
+				});
+			} else {
+				btn.setAttribute("disabled", "disabled");
+				btn.setAttribute("aria-disabled", "true");
+			}
+
+			li.appendChild(btn);
+			ul.appendChild(li);
+		});
+
+		var statusEl = $("#status-bar");
+		if (state.devMode) {
+			statusEl.textContent = "Modo desarrollo: índice en este navegador (localStorage).";
+			statusEl.classList.remove("status-bar--error");
+		} else if (state.lastError) {
+			statusEl.textContent = state.lastError;
+			statusEl.classList.add("status-bar--error");
+		} else {
+			statusEl.textContent = "Sincronizado · actualización cada " + POLL_MS / 1000 + " s";
+			statusEl.classList.remove("status-bar--error");
+		}
+
+		attachCipherLines(listEl);
+	}
+
+	function renderDetail(id) {
+		var listEl = $("#view-list");
+		var detailEl = $("#view-detail");
+		if (!listEl || !detailEl) return;
+
+		var idx = getSongIndexById(id);
+		var song = idx >= 0 ? state.setlist.songs[idx] : null;
+
+		if (!song || !isUnlocked(idx)) {
+			setHashList();
+			return;
+		}
+
+		listEl.classList.add("hidden");
+		detailEl.classList.remove("hidden");
+
+		$("#detail-title").textContent = song.title || "";
+		$("#about-text").textContent = song.about || "";
+		var lyricsEl = $("#lyrics-text");
+		lyricsEl.textContent = song.lyrics || "";
+
+		$("#btn-back").onclick = function () {
+			setHashList();
+		};
+
+		clearCipherTimers();
+	}
+
+	function render() {
+		if (!state.setlist) return;
+		var songs = state.setlist.songs || [];
+		var max = Math.max(0, songs.length - 1);
+		state.currentIndex = Math.min(Math.max(0, state.currentIndex), max);
+		var route = parseHash();
+		if (route.view === "detail" && route.id) {
+			renderDetail(route.id);
+		} else {
+			renderList();
+		}
+	}
+
+	function init() {
+		state.devMode = isDevMode();
+
+		fetch("data/setlist.json", { cache: "no-store" })
+			.then(function (r) {
+				if (!r.ok) throw new Error("setlist");
+				return r.json();
+			})
+			.then(function (data) {
+				state.setlist = data;
+				window.addEventListener("hashchange", render);
+				startPolling();
+				render();
+			})
+			.catch(function () {
+				$("#meta-title").textContent = "Error";
+				$("#meta-subtitle").textContent = "No se pudo cargar la lista.";
+			});
+
+		if (state.devMode) {
+			var b = document.createElement("div");
+			b.className = "dev-banner";
+			b.textContent = "Dev · ?dev=1 — índice solo en este dispositivo";
+			document.body.appendChild(b);
+		}
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", init);
+	} else {
+		init();
+	}
+})();

--- a/presentacion-album-mdufc/js/operator.js
+++ b/presentacion-album-mdufc/js/operator.js
@@ -1,0 +1,197 @@
+(function () {
+	"use strict";
+
+	var API_SET = "api/set.php";
+	var STORAGE_SECRET = "presentacion_mdufc_operator_secret";
+	var STORAGE_DEV = "presentacion_mdufc_dev_index";
+
+	function $(sel) {
+		return document.querySelector(sel);
+	}
+
+	function isDevMode() {
+		try {
+			return new URLSearchParams(window.location.search).get("dev") === "1";
+		} catch (e) {
+			return false;
+		}
+	}
+
+	var state = {
+		setlist: null,
+		currentIndex: 0,
+		devMode: false,
+	};
+
+	function loadSetlist() {
+		return fetch("data/setlist.json", { cache: "no-store" }).then(function (r) {
+			if (!r.ok) throw new Error("setlist");
+			return r.json();
+		});
+	}
+
+	function fetchState() {
+		if (state.devMode) {
+			var raw = localStorage.getItem(STORAGE_DEV);
+			var n = raw === null ? 0 : parseInt(raw, 10);
+			if (isNaN(n)) n = 0;
+			return Promise.resolve({ currentIndex: n });
+		}
+		return fetch("api/state.php", { cache: "no-store" }).then(function (r) {
+			if (!r.ok) throw new Error("state");
+			return r.json();
+		});
+	}
+
+	function maxIndex() {
+		var n = (state.setlist && state.setlist.songs && state.setlist.songs.length) || 0;
+		return Math.max(0, n - 1);
+	}
+
+	function updatePreview() {
+		var songs = (state.setlist && state.setlist.songs) || [];
+		var el = $("#preview-song");
+		if (!el) return;
+		var s = songs[state.currentIndex];
+		el.textContent = s ? s.title : "—";
+		$("#preview-index").textContent = String(state.currentIndex + 1) + " / " + songs.length;
+	}
+
+	function setStatus(msg, isErr) {
+		var bar = $("#operator-status");
+		if (!bar) return;
+		bar.textContent = msg;
+		bar.classList.toggle("status-bar--error", !!isErr);
+	}
+
+	function sendAction(action) {
+		if (state.devMode) {
+			var max = maxIndex();
+			var raw = localStorage.getItem(STORAGE_DEV);
+			var idx = raw === null ? 0 : parseInt(raw, 10);
+			if (isNaN(idx)) idx = 0;
+			if (action === "next") idx = Math.min(max, idx + 1);
+			else if (action === "prev") idx = Math.max(0, idx - 1);
+			else if (action === "reset") idx = 0;
+			localStorage.setItem(STORAGE_DEV, String(idx));
+			state.currentIndex = idx;
+			updatePreview();
+			setStatus("Modo dev · índice local " + idx, false);
+			return;
+		}
+
+		var secret = ($("#operator-secret") && $("#operator-secret").value) || "";
+		if (!secret.trim()) {
+			setStatus("Ingresá el secreto del operador (config.php en el servidor).", true);
+			return;
+		}
+
+		setStatus("Enviando…", false);
+
+		fetch(API_SET, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ secret: secret, action: action }),
+		})
+			.then(function (r) {
+				return r.json().then(function (data) {
+					return { ok: r.ok, status: r.status, data: data };
+				});
+			})
+			.then(function (res) {
+				if (!res.ok || !res.data.ok) {
+					var err = (res.data && res.data.error) || "Error " + res.status;
+					throw new Error(err);
+				}
+				state.currentIndex = res.data.currentIndex;
+				try {
+					sessionStorage.setItem(STORAGE_SECRET, secret);
+				} catch (e) {}
+				updatePreview();
+				setStatus("Listo · índice " + state.currentIndex, false);
+			})
+			.catch(function (e) {
+				setStatus(e.message || "Falló la petición.", true);
+			});
+	}
+
+	function syncFromServer() {
+		if (state.devMode) {
+			fetchState()
+				.then(function (data) {
+					var idx = parseInt(data.currentIndex, 10);
+					if (isNaN(idx)) idx = 0;
+					state.currentIndex = Math.min(Math.max(0, idx), maxIndex());
+					updatePreview();
+					setStatus("Dev · índice " + state.currentIndex, false);
+				})
+				.catch(function () {});
+			return;
+		}
+		fetchState()
+			.then(function (data) {
+				var idx = parseInt(data.currentIndex, 10);
+				if (isNaN(idx)) idx = 0;
+				state.currentIndex = Math.min(Math.max(0, idx), maxIndex());
+				updatePreview();
+				setStatus("Estado remoto: índice " + state.currentIndex, false);
+			})
+			.catch(function () {
+				setStatus("No se pudo leer api/state.php (¿servidor PHP local?)", true);
+			});
+	}
+
+	function init() {
+		state.devMode = isDevMode();
+		if (state.devMode) {
+			var b = document.createElement("div");
+			b.className = "dev-banner";
+			b.textContent = "Dev · ?dev=1 — mismo localStorage que el público";
+			document.body.appendChild(b);
+			var sec = $("#operator-secret");
+			if (sec) {
+				sec.disabled = true;
+				sec.placeholder = "No usado en modo dev";
+			}
+		}
+
+		var saved = "";
+		try {
+			saved = sessionStorage.getItem(STORAGE_SECRET) || "";
+		} catch (e) {}
+		if (saved && $("#operator-secret") && !state.devMode) $("#operator-secret").value = saved;
+
+		loadSetlist()
+			.then(function (data) {
+				state.setlist = data;
+				return fetchState();
+			})
+			.then(function (data) {
+				var idx = parseInt(data.currentIndex, 10);
+				if (isNaN(idx)) idx = 0;
+				state.currentIndex = Math.min(Math.max(0, idx), maxIndex());
+				updatePreview();
+				setStatus("Conectado.", false);
+			})
+			.catch(function () {
+				setStatus("Revisá data/setlist.json y que PHP esté activo.", true);
+			});
+
+		$("#btn-next").addEventListener("click", function () {
+			sendAction("next");
+		});
+		$("#btn-prev").addEventListener("click", function () {
+			sendAction("prev");
+		});
+		$("#btn-reset").addEventListener("click", function () {
+			if (window.confirm("¿Volver al inicio del set (índice 0)?")) sendAction("reset");
+		});
+		$("#btn-refresh").addEventListener("click", syncFromServer);
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", init);
+	} else {
+		init();
+	}
+})();

--- a/presentacion-album-mdufc/operator.html
+++ b/presentacion-album-mdufc/operator.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<title>Operador — Presentación MDUFC</title>
+	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
+	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+	<link rel="stylesheet" href="css/live.css">
+</head>
+<body>
+	<div class="app-wrap">
+		<header class="header-block">
+			<p class="kicker">Control en vivo</p>
+			<h1 class="font-display">Operador</h1>
+			<p class="sub">Siguiente / anterior · mismo secreto que <code>config.php</code></p>
+		</header>
+
+		<div class="panel">
+			<label class="section-label" for="operator-secret" style="display:block;margin-bottom:8px;">Secreto</label>
+			<input type="password" id="operator-secret" class="input-secret" placeholder="OPERATOR_SECRET" autocomplete="off">
+
+			<div class="operator-preview">
+				<p class="label">Tema actual (índice servidor)</p>
+				<p class="song-name" id="preview-song">—</p>
+				<p class="sub" id="preview-index" style="margin-top:8px;">—</p>
+			</div>
+
+			<div class="operator-actions">
+				<button type="button" class="btn" id="btn-prev">← Anterior</button>
+				<button type="button" class="btn btn-primary-solid" id="btn-next">Siguiente →</button>
+			</div>
+			<div class="operator-actions" style="margin-top:8px;">
+				<button type="button" class="btn btn-ghost" id="btn-reset">Ir al inicio</button>
+				<button type="button" class="btn btn-ghost" id="btn-refresh">Refrescar estado</button>
+			</div>
+
+			<p class="status-bar" id="operator-status"></p>
+		</div>
+	</div>
+	<script src="js/operator.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Qué incluye
- Carpeta `presentacion-album-mdufc/`: listado con temas bloqueados (gris + línea cifrada), detalle letra + de qué habla, polling a `api/state.php`, operador con `api/set.php`, estética n0m10s, modo `?dev=1`.
- `README.md` y `APPLY_WORKFLOWS.md` + `apply-workflows.patch` para inyectar el secreto de GitHub en deploy (ver abajo).

## Workflows de GitHub
Este PR **no** modifica `.github/workflows/` (el token del entorno no tiene permiso `workflow`). Para que `PRESENTACION_MDUFC_OPERATOR_SECRET` genere `config.php` en cada deploy, en tu máquina:

```bash
git apply presentacion-album-mdufc/apply-workflows.patch
git add .github/workflows/
git commit -m "ci: generar config.php MDUFC desde secreto en deploy"
git push
```

(O abrí un PR aparte con ese cambio.)

## Post-merge
Merge a `develop` → deploy staging; probar público + operador con el secreto.

Made with [Cursor](https://cursor.com)