### PR TITLE
Presentación: evitar caché de app.js (carga dinámica + meta)

### DIFF
--- a/presentacion-album-mdufc/index.html
+++ b/presentacion-album-mdufc/index.html
@@ -3,10 +3,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+	<meta http-equiv="Pragma" content="no-cache">
 	<title>Mitos de un futuro cercano — Hacia el Ocaso</title>
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/live.css?v=3">
+	<link rel="stylesheet" href="css/live.css?v=5">
 </head>
 <body>
 	<div id="matrix-bg" aria-hidden="true">
@@ -47,7 +49,21 @@
 			</div>
 		</div>
 	</div>
-	<script src="js/matrix-bg.js?v=3"></script>
-	<script src="js/app.js?v=3"></script>
+	<script>
+	(function () {
+		var bust = "_=" + Date.now();
+		function loadScript(src, onload) {
+			var s = document.createElement("script");
+			s.src = src + (src.indexOf("?") >= 0 ? "&" : "?") + bust;
+			s.async = false;
+			if (onload) s.onload = onload;
+			s.onerror = onload || function () {};
+			document.body.appendChild(s);
+		}
+		loadScript("js/matrix-bg.js", function () {
+			loadScript("js/app.js");
+		});
+	})();
+	</script>
 </body>
 </html>

--- a/presentacion-album-mdufc/operator.html
+++ b/presentacion-album-mdufc/operator.html
@@ -3,10 +3,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+	<meta http-equiv="Pragma" content="no-cache">
 	<title>Operador — Mitos de un futuro cercano</title>
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/live.css?v=3">
+	<link rel="stylesheet" href="css/live.css?v=5">
 </head>
 <body>
 	<div id="matrix-bg" aria-hidden="true">
@@ -46,7 +48,21 @@
 			<p class="status-bar" id="operator-status"></p>
 		</div>
 	</div>
-	<script src="js/matrix-bg.js?v=3"></script>
-	<script src="js/operator.js?v=3"></script>
+	<script>
+	(function () {
+		var bust = "_=" + Date.now();
+		function loadScript(src, onload) {
+			var s = document.createElement("script");
+			s.src = src + (src.indexOf("?") >= 0 ? "&" : "?") + bust;
+			s.async = false;
+			if (onload) s.onload = onload;
+			s.onerror = onload || function () {};
+			document.body.appendChild(s);
+		}
+		loadScript("js/matrix-bg.js", function () {
+			loadScript("js/operator.js");
+		});
+	})();
+	</script>
 </body>
 </html>

--- a/presentacion-album-mdufc/share.html
+++ b/presentacion-album-mdufc/share.html
@@ -3,12 +3,14 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+	<meta http-equiv="Pragma" content="no-cache">
 	<title>Tu foto — Mitos de un futuro cercano · Hacia el Ocaso</title>
 	<meta name="description" content="Creá una imagen con glitch, colores del disco y marcas para compartir en redes.">
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/live.css?v=3">
-	<link rel="stylesheet" href="css/share.css?v=3">
+	<link rel="stylesheet" href="css/live.css?v=5">
+	<link rel="stylesheet" href="css/share.css?v=5">
 </head>
 <body class="share-page">
 	<div id="matrix-bg" aria-hidden="true">
@@ -46,7 +48,21 @@
 		</div>
 		<a class="share-back" href="index.html">← Volver al show</a>
 	</div>
-	<script src="js/matrix-bg.js?v=3"></script>
-	<script src="js/share-photo.js?v=3"></script>
+	<script>
+	(function () {
+		var bust = "_=" + Date.now();
+		function loadScript(src, onload) {
+			var s = document.createElement("script");
+			s.src = src + (src.indexOf("?") >= 0 ? "&" : "?") + bust;
+			s.async = false;
+			if (onload) s.onload = onload;
+			s.onerror = onload || function () {};
+			document.body.appendChild(s);
+		}
+		loadScript("js/matrix-bg.js", function () {
+			loadScript("js/share-photo.js");
+		});
+	})();
+	</script>
 </body>
 </html>


### PR DESCRIPTION
## Qué hace este PR

En producción seguía viéndose la UI antigua (nombres de temas futuros, cifrado animado, pausas) porque el navegador servía **`app.js` cacheado** aunque el repo ya tuviera la lógica nueva.

## Cambios

- **`index.html`**, **`operator.html`**, **`share.html`**: los scripts se cargan con un **query único por visita** (`\_=` + `Date.now()`) en lugar de `?v=3` fijo.
- Orden garantizado: primero **`matrix-bg.js`**, luego **`app.js`** / **`operator.js`** / **`share-photo.js`**. Si Matrix falla al cargar, igual se intenta el siguiente script.
- Meta **`Cache-Control` / `Pragma`** en el HTML para reducir HTML pegado en caché.
- **CSS** a **`?v=5`** en esas páginas.

Tras merge y deploy, los usuarios deberían recibir siempre el JS actual sin depender de un hard refresh manual.

Made with [Cursor](https://cursor.com)