### PR TITLE
Presentación UI + n0m10s móvil (→ main)

### DIFF
--- a/n0m10s/index.html
+++ b/n0m10s/index.html
@@ -240,14 +240,16 @@
 		}
 		#terminal-body {
 			flex: 1;
-			padding: 40px 32px 48px 32px;
-			overflow-y: auto;
+			display: flex;
+			flex-direction: column;
+			min-height: 0;
+			padding: max(40px, env(safe-area-inset-top, 0px)) max(32px, env(safe-area-inset-right, 0px)) max(48px, env(safe-area-inset-bottom, 0px)) max(32px, env(safe-area-inset-left, 0px));
+			overflow: hidden;
 			position: relative;
 			background: transparent;
 			color: var(--text);
 			font-size: 0.95rem;
 			line-height: 1.8;
-			/* pre-wrap solo en salida: en el input heredaba y los \\n del HTML entre <span> partían el prompt */
 			white-space: normal;
 			word-wrap: break-word;
 			font-family: 'Geist Mono', 'JetBrains Mono', monospace;
@@ -258,7 +260,10 @@
 			text-align: left;
 		}
 		#terminal-output {
-			min-height: 120px;
+			flex: 1 1 auto;
+			min-height: 80px;
+			overflow-y: auto;
+			-webkit-overflow-scrolling: touch;
 			text-align: left;
 			white-space: pre-wrap;
 		}
@@ -270,6 +275,7 @@
 		.prompt-arrow { color: rgba(255,255,255,0.9); }
 		/* Grid: alineación estable a la izquierda (flex+wrap+center podía centrar el bloque del prompt) */
 		.terminal-input-line {
+			flex-shrink: 0;
 			display: grid;
 			grid-template-columns: minmax(0, 1fr);
 			gap: 10px;
@@ -360,17 +366,17 @@
 		}
 		.nomios-response { color: #5edcc4; margin: 8px 0; white-space: pre-wrap; line-height: 1.7; text-align: left; }
 		.msg-text { color: var(--text); }
-		.system-msg { color: #22eec9; text-align: left; }
+		.system-msg { color: #22eec9; text-align: left; white-space: pre-line; line-height: 1.65; }
 		.error-msg { color: #f87171; }
 		.loading { color: #6ef5dc; font-style: italic; opacity: 0.9; text-align: left; }
 		#terminal-logo {
 			position: absolute;
-			top: 24px;
-			right: 40px;
+			top: max(16px, env(safe-area-inset-top, 0px));
+			right: max(24px, env(safe-area-inset-right, 0px));
 			width: 40px;
-			opacity: 0.2;
+			opacity: 0.32;
 			pointer-events: none;
-			filter: drop-shadow(0 0 12px rgba(34,238,201,0.2));
+			filter: drop-shadow(0 0 12px rgba(34,238,201,0.25));
 		}
 		/* Mobile */
 		@media (max-width: 480px) {
@@ -381,8 +387,18 @@
 			#login-btn { min-height: 44px; }
 			.matrix-logo-wrap { padding: 28px 32px 20px; margin: -16px 0 8px; }
 			#matrix-logo { width: 140px; }
-			#terminal-body { padding: 16px; overflow-x: hidden; }
-			.terminal-input-line { width: 100%; box-sizing: border-box; }
+			#terminal-body {
+				padding: max(14px, env(safe-area-inset-top, 0px)) 14px max(20px, env(safe-area-inset-bottom, 0px)) 14px;
+				overflow-x: hidden;
+			}
+			#terminal-output { min-height: min(36vh, 220px); }
+			.terminal-input-line { width: 100%; box-sizing: border-box; margin-top: 12px; }
+			#terminal-logo {
+				width: 44px;
+				opacity: 0.42;
+				top: max(10px, env(safe-area-inset-top, 0px));
+				right: max(12px, env(safe-area-inset-right, 0px));
+			}
 			#terminal-output, .terminal-line, .nomios-response { font-size: 0.85rem; }
 			.terminal-input-line { min-width: 0; }
 			.prompt-inline {
@@ -680,7 +696,7 @@
 				terminalContainer.classList.add('visible');
 				document.getElementById('prompt-user-host').textContent = currentUserName + '@OcasoCore';
 				const inp = document.getElementById('terminal-input');
-				appendOutput('> Sistema n0m10s conectado. Escribe y Enter para hablar con Nomios.', 'normal');
+				appendOutput('> Sistema n0m10s conectado.\n> Escribe y pulsa Enter para hablar con Nomios.', 'normal');
 				setTimeout(() => {
 					try { inp.focus({ preventScroll: true }); } catch (_) { inp.focus(); }
 				}, 100);

--- a/presentacion-album-mdufc/css/share.css
+++ b/presentacion-album-mdufc/css/share.css
@@ -102,6 +102,8 @@
 	display: block;
 	width: 100%;
 	height: auto;
+	/* Misma relación que 1080×1350: evita que en móvil se estire solo en un eje */
+	aspect-ratio: 1080 / 1350;
 	vertical-align: middle;
 }
 

--- a/presentacion-album-mdufc/js/share-photo.js
+++ b/presentacion-album-mdufc/js/share-photo.js
@@ -38,6 +38,19 @@
 		};
 	}
 
+	/** Dibuja la imagen dentro del rectángulo sin deformar (como object-fit: contain). */
+	function drawImageContain(img, boxX, boxY, boxW, boxH) {
+		var iw = img.naturalWidth;
+		var ih = img.naturalHeight;
+		if (iw <= 0 || ih <= 0) return;
+		var scale = Math.min(boxW / iw, boxH / ih);
+		var dw = iw * scale;
+		var dh = ih * scale;
+		var ox = boxX + (boxW - dw) / 2;
+		var oy = boxY + (boxH - dh) / 2;
+		ctx.drawImage(img, 0, 0, iw, ih, ox, oy, dw, dh);
+	}
+
 	function drawCoverImage(img, w, h) {
 		var ir = img.naturalWidth / img.naturalHeight;
 		var vr = w / h;
@@ -160,6 +173,7 @@
 		ctx.save();
 		ctx.translate(cx, cy);
 		ctx.rotate(angle);
+		/* Escala uniforme para no aplastar las formas */
 		ctx.scale(scale, scale);
 		ctx.globalAlpha = alpha;
 		var blue = "rgba(72, 148, 255, 0.72)";
@@ -189,7 +203,8 @@
 
 		ctx.fillStyle = "rgba(180, 210, 255, 0.35)";
 		ctx.beginPath();
-		ctx.ellipse(0, 0, 3, 14, 0, 0, Math.PI * 2);
+		/* Cuerpo más redondo: con 3×14 y rotación fuerte parecía una raya aplastada */
+		ctx.ellipse(0, 0, 5, 11, 0, 0, Math.PI * 2);
 		ctx.fill();
 
 		ctx.restore();
@@ -211,7 +226,7 @@
 			px = positions[k][0] * OUT_W + (rand() - 0.5) * 40;
 			py = positions[k][1] * OUT_H + (rand() - 0.5) * 40;
 			sc = positions[k][2] * (0.9 + rand() * 0.35);
-			ang = (rand() - 0.5) * 1.2;
+			ang = (rand() - 0.5) * 0.85;
 			drawButterfly(px, py, sc, ang, 0.75 + rand() * 0.2);
 		}
 	}
@@ -224,7 +239,7 @@
 			ctx.globalAlpha = 0.92;
 			ctx.shadowColor = "rgba(34, 238, 201, 0.5)";
 			ctx.shadowBlur = 24;
-			ctx.drawImage(logoImg, OUT_W - logoSize - pad, pad, logoSize, logoSize);
+			drawImageContain(logoImg, OUT_W - logoSize - pad, pad, logoSize, logoSize);
 			ctx.restore();
 		}
 

--- a/presentacion-album-mdufc/share.html
+++ b/presentacion-album-mdufc/share.html
@@ -10,7 +10,7 @@
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="css/live.css?v=6">
-	<link rel="stylesheet" href="css/share.css?v=5">
+	<link rel="stylesheet" href="css/share.css?v=6">
 </head>
 <body class="share-page">
 	<div id="matrix-bg" aria-hidden="true">


### PR DESCRIPTION
## Incluye

- **presentacion-album-mdufc:** estilos Pasó / Nomios legible, badge Pasó, `live.css?v=6` (commit anterior en esta rama si aún no está en main).
- **n0m10s:** terminal con salida flexible y prompt abajo, bienvenida en dos líneas, logo y safe area en móvil.

Objetivo: merge directo a **main** para deploy en producción.

Made with [Cursor](https://cursor.com)