### PR TITLE
heo v2: hero contenido + contacto rediseñado + page glitch

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -303,10 +303,10 @@ body::after {
 
 .hero__title {
   font-family: var(--font-display);
-  font-size: clamp(3.25rem, 14vw, 13rem);
+  font-size: clamp(2.75rem, 10vw, 7.5rem);
   font-weight: 700;
-  line-height: 0.86;
-  letter-spacing: -0.045em;
+  line-height: 0.92;
+  letter-spacing: -0.035em;
   text-transform: uppercase;
   margin-bottom: 1.75rem;
 }
@@ -817,58 +817,188 @@ body::after {
 /* ============================================================
    CONTACTO
    ============================================================ */
-.contact-wrap {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4rem;
-  align-items: start;
-}
 
-.contact-block__label {
+/* CTA email destacado — ocupa full width, look terminal */
+.contact-hero {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.75rem 2rem;
+  margin-bottom: 1.5rem;
+  background: linear-gradient(100deg, rgba(34,238,201,0.06), rgba(34,238,201,0.015) 60%);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  color: var(--text);
+  transition: all 0.4s var(--ease-out);
+  position: relative;
+  overflow: hidden;
+  animation: breathe-border 4.5s ease-in-out infinite;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 20px) 0,
+    100% 20px,
+    100% 100%,
+    20px 100%,
+    0 calc(100% - 20px)
+  );
+}
+.contact-hero::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0;
+  width: 3px; height: 100%;
+  background: linear-gradient(to bottom, transparent, var(--accent), transparent);
+  animation: breathe-bar 3.5s ease-in-out infinite;
+}
+.contact-hero:hover {
+  background: linear-gradient(100deg, rgba(34,238,201,0.12), rgba(34,238,201,0.03) 60%);
+  transform: translateY(-2px);
+  box-shadow: 0 0 40px rgba(34,238,201,0.12);
+}
+.contact-hero__prompt {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+.contact-hero__email {
+  font-family: var(--font-display);
+  font-size: clamp(1.3rem, 3.5vw, 2.1rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.contact-hero__tag {
   font-family: var(--font-mono);
   font-size: 0.68rem;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin-bottom: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  flex-shrink: 0;
 }
-.contact-block__value {
-  font-size: 1.1rem;
-  color: var(--text);
+.contact-hero__arrow {
+  color: var(--accent);
+  flex-shrink: 0;
+  transition: transform 0.3s var(--ease-out);
+}
+.contact-hero:hover .contact-hero__arrow { transform: translateX(6px); }
+
+/* Grid de redes sociales */
+.social-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
   margin-bottom: 2rem;
 }
-.contact-block__value a {
-  transition: color 0.3s;
-}
-.contact-block__value a:hover { color: var(--accent); }
 
-.social-row {
+.social-card {
   display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-top: 1.5rem;
-}
-
-.social-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.75rem 1.2rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.45rem;
+  padding: 1.4rem 1.25rem 1.25rem;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  color: var(--text-muted);
-  font-size: 0.83rem;
-  font-weight: 500;
-  transition: all 0.3s var(--ease-out);
-  min-height: 44px;
+  color: var(--text);
+  text-decoration: none;
+  transition: all 0.35s var(--ease-out);
+  position: relative;
+  overflow: hidden;
+  min-height: 140px;
 }
-.social-btn svg { flex-shrink: 0; }
-.social-btn:hover {
+.social-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0;
+  width: 24px; height: 1px;
+  background: var(--accent);
+  transition: width 0.35s var(--ease-out);
+  opacity: 0.7;
+}
+.social-card:hover {
   border-color: var(--accent-border);
+  background: rgba(34, 238, 201, 0.035);
+  transform: translateY(-3px);
+  box-shadow: 0 0 32px rgba(34, 238, 201, 0.1);
+}
+.social-card:hover::before { width: 100%; }
+.social-card__icon {
+  color: var(--text-muted);
+  transition: color 0.3s, filter 0.3s;
+  margin-bottom: 0.35rem;
+}
+.social-card:hover .social-card__icon {
   color: var(--accent);
-  background: var(--accent-bg);
-  transform: translateY(-2px);
-  box-shadow: 0 0 22px rgba(34, 238, 201, 0.09);
+  filter: drop-shadow(0 0 10px rgba(34,238,201,0.5));
+}
+.social-card__name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+.social-card__handle {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin-top: auto;
+}
+
+/* Footnote con link a nomios */
+.contact-footnote {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+.contact-footnote__label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.contact-footnote__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  transition: color 0.3s;
+}
+.contact-footnote__link:hover { color: var(--accent); }
+
+/* Contacto — responsive */
+@media (max-width: 820px) {
+  .social-grid { grid-template-columns: repeat(2, 1fr); }
+  .contact-hero {
+    flex-wrap: wrap;
+    padding: 1.4rem 1.5rem;
+    gap: 0.8rem;
+  }
+  .contact-hero__tag { order: 3; }
+  .contact-hero__arrow { order: 4; margin-left: auto; }
+}
+@media (max-width: 480px) {
+  .social-grid { grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+  .social-card { min-height: 120px; padding: 1.1rem 1rem; }
+  .contact-hero__email { font-size: 1.15rem; }
+  .contact-hero__prompt { display: none; }
 }
 
 
@@ -1078,10 +1208,6 @@ body::after {
     grid-template-columns: 1fr;
     max-width: 540px;
     margin: 0 auto;
-  }
-  .contact-wrap {
-    grid-template-columns: 1fr;
-    gap: 3rem;
   }
 }
 
@@ -1372,6 +1498,53 @@ body::after { opacity: 0.065; }
 /* --- Member cards: borde izquierdo accent al hover --- */
 .member-card:hover .member-card__name {
   text-shadow: 0 0 12px rgba(34,238,201,0.4);
+}
+
+/* ============================================================
+   PAGE GLITCH — afecta toda la página cada tanto
+   ============================================================ */
+@keyframes page-glitch {
+  0%   { transform: translate(0, 0); filter: none; }
+  10%  { transform: translate(-2px, 1px); filter: hue-rotate(8deg) saturate(1.1); }
+  20%  { transform: translate(3px, -2px) skewX(-0.6deg); filter: hue-rotate(-4deg); }
+  30%  { transform: translate(-1px, 2px); filter: brightness(1.15) contrast(1.08); }
+  45%  { transform: translate(0, 0); filter: none; }
+  55%  { transform: translate(2px, 0) skewX(0.4deg); filter: saturate(1.25); }
+  70%  { transform: translate(-3px, -1px); filter: hue-rotate(6deg); }
+  85%  { transform: translate(1px, 1px); filter: none; }
+  100% { transform: translate(0, 0); filter: none; }
+}
+@keyframes page-glitch-overlay {
+  0%, 100% { opacity: 0; }
+  10%      { opacity: 0.55; }
+  30%      { opacity: 0.25; }
+  55%      { opacity: 0.6; }
+  80%      { opacity: 0.2; }
+}
+
+body.is-glitching {
+  animation: page-glitch 620ms steps(1, end);
+}
+body.is-glitching::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(34, 238, 201, 0.08) 0 2px,
+      transparent 2px 5px
+    ),
+    linear-gradient(90deg, rgba(255, 20, 120, 0.12), transparent 30%, rgba(34, 238, 201, 0.14) 70%, transparent);
+  animation: page-glitch-overlay 620ms steps(1, end);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.is-glitching,
+  body.is-glitching::after { animation: none !important; }
 }
 
 /* ============================================================

--- a/index_new.html
+++ b/index_new.html
@@ -493,79 +493,78 @@
         <h2 class="section__title">Contacto</h2>
       </header>
 
-      <div class="contact-wrap">
+      <!-- CTA email destacado -->
+      <a href="mailto:haciaelocaso@gmail.com" class="contact-hero reveal">
+        <span class="contact-hero__prompt" aria-hidden="true">$ mailto:_</span>
+        <span class="contact-hero__email">haciaelocaso@gmail.com</span>
+        <span class="contact-hero__tag">booking · prensa · management</span>
+        <svg class="contact-hero__arrow" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+          <path d="M5 12h14M13 5l7 7-7 7"/>
+        </svg>
+      </a>
 
-        <!-- Redes sociales -->
-        <div class="reveal">
-          <p class="contact-block__label">Seguinos</p>
-          <div class="social-row">
+      <!-- Grid de redes sociales -->
+      <div class="social-grid reveal" role="list">
 
-            <a href="https://www.instagram.com/haciaelocaso"
-               class="social-btn"
-               target="_blank" rel="noopener noreferrer"
-               aria-label="Instagram de Hacia el Ocaso">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
-              </svg>
-              Instagram
-            </a>
+        <a href="https://www.instagram.com/haciaelocaso"
+           class="social-card"
+           target="_blank" rel="noopener noreferrer"
+           role="listitem"
+           aria-label="Instagram de Hacia el Ocaso">
+          <svg class="social-card__icon" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+          </svg>
+          <span class="social-card__name">Instagram</span>
+          <span class="social-card__handle">@haciaelocaso</span>
+        </a>
 
-            <a href="https://www.youtube.com/@haciaelocaso"
-               class="social-btn"
-               target="_blank" rel="noopener noreferrer"
-               aria-label="YouTube de Hacia el Ocaso">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
-              </svg>
-              YouTube
-            </a>
+        <a href="https://www.youtube.com/@haciaelocaso"
+           class="social-card"
+           target="_blank" rel="noopener noreferrer"
+           role="listitem"
+           aria-label="YouTube de Hacia el Ocaso">
+          <svg class="social-card__icon" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+          </svg>
+          <span class="social-card__name">YouTube</span>
+          <span class="social-card__handle">@haciaelocaso</span>
+        </a>
 
-            <a href="https://open.spotify.com/playlist/6So94YyGUL4HI45JjLzbAp"
-               class="social-btn"
-               target="_blank" rel="noopener noreferrer"
-               aria-label="Spotify de Hacia el Ocaso">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-              </svg>
-              Spotify
-            </a>
+        <a href="https://open.spotify.com/playlist/6So94YyGUL4HI45JjLzbAp"
+           class="social-card"
+           target="_blank" rel="noopener noreferrer"
+           role="listitem"
+           aria-label="Spotify de Hacia el Ocaso">
+          <svg class="social-card__icon" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+          </svg>
+          <span class="social-card__name">Spotify</span>
+          <span class="social-card__handle">Mitos · TRSCNDR · Amanecer</span>
+        </a>
 
-            <a href="https://linktr.ee/haciaelocaso"
-               class="social-btn"
-               target="_blank" rel="noopener noreferrer"
-               aria-label="Linktree de Hacia el Ocaso">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M13.051 8.938l4.549-4.719 2.16 2.08-4.699 4.559 6.939.023v2.994l-6.939.024 4.699 4.559-2.16 2.08-4.549-4.72v6.182h-3v-6.182l-4.549 4.72-2.16-2.08 4.699-4.559-6.939-.024V10.88l6.939-.023-4.699-4.559 2.16-2.08 4.549 4.719V2.757h3v6.181z"/>
-              </svg>
-              Linktree
-            </a>
+        <a href="https://linktr.ee/haciaelocaso"
+           class="social-card"
+           target="_blank" rel="noopener noreferrer"
+           role="listitem"
+           aria-label="Linktree de Hacia el Ocaso">
+          <svg class="social-card__icon" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M13.051 8.938l4.549-4.719 2.16 2.08-4.699 4.559 6.939.023v2.994l-6.939.024 4.699 4.559-2.16 2.08-4.549-4.72v6.182h-3v-6.182l-4.549 4.72-2.16-2.08 4.699-4.559-6.939-.024V10.88l6.939-.023-4.699-4.559 2.16-2.08 4.549 4.719V2.757h3v6.181z"/>
+          </svg>
+          <span class="social-card__name">Linktree</span>
+          <span class="social-card__handle">linktr.ee/haciaelocaso</span>
+        </a>
 
-          </div>
-        </div>
+      </div>
 
-        <!-- Info de contacto -->
-        <div class="reveal">
-          <p class="contact-block__label">Contacto profesional</p>
-          <p class="contact-block__value">
-            <a href="mailto:haciaelocaso@gmail.com">haciaelocaso@gmail.com</a>
-          </p>
-          <p class="contact-block__label">Todo el contenido</p>
-          <p class="contact-block__value">
-            <a href="https://linktr.ee/haciaelocaso"
-               target="_blank" rel="noopener noreferrer">
-              linktr.ee/haciaelocaso
-            </a>
-          </p>
-          <a href="n0m10s/"
-             class="btn btn--ghost"
-             style="margin-top:0.5rem">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-              <circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/>
-            </svg>
-            Nomios AI
-          </a>
-        </div>
-
+      <!-- Lab link (Nomios AI) -->
+      <div class="contact-footnote reveal">
+        <span class="contact-footnote__label">// lab</span>
+        <a href="n0m10s/" class="contact-footnote__link">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/>
+          </svg>
+          Nomios AI — experiencia interactiva
+        </a>
       </div>
     </div>
   </section>

--- a/js/heo-v2.js
+++ b/js/heo-v2.js
@@ -390,6 +390,41 @@ document.querySelectorAll('a[href^="#"]').forEach(a => {
 
 
 /* ============================================================
+   PAGE GLITCH — cada tanto la página parpadea
+   ============================================================ */
+(function initPageGlitch() {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  const body = document.body;
+  const MIN_GAP = 9000;   // 9s mínimo entre glitches
+  const MAX_GAP = 22000;  // 22s máximo
+
+  function trigger() {
+    body.classList.add('is-glitching');
+    setTimeout(() => body.classList.remove('is-glitching'), 650);
+
+    /* 25% de las veces: glitch doble rápido */
+    if (Math.random() < 0.25) {
+      setTimeout(() => {
+        body.classList.add('is-glitching');
+        setTimeout(() => body.classList.remove('is-glitching'), 650);
+      }, 900);
+    }
+
+    schedule();
+  }
+
+  function schedule() {
+    const wait = MIN_GAP + Math.random() * (MAX_GAP - MIN_GAP);
+    setTimeout(trigger, wait);
+  }
+
+  /* Primer glitch entre 5-12s después de cargar */
+  setTimeout(trigger, 5000 + Math.random() * 7000);
+})();
+
+
+/* ============================================================
    AMBIENT — aumentar intensidad de orbes
    ============================================================ */
 /* Los orbes ya están definidos en initAmbient().


### PR DESCRIPTION
Follow-up a #43. Ajustes post-review visual.

## Cambios

### Hero title más contenido
- `clamp(3.25rem, 14vw, 13rem)` → `clamp(2.75rem, 10vw, 7.5rem)`.
- En desktop 'MITOS DE UN FUTURO CERCANO' ahora cabe en 2 líneas sin invadir toda la pantalla; en mobile sigue imponente.
- `line-height` 0.86 → 0.92 y `letter-spacing` -0.045em → -0.035em para respirar mejor al tamaño menor.

### Contacto rediseñado
- Reemplaza el layout de dos columnas por una jerarquía más fuerte:
  1. **CTA email destacado** (`contact-hero`): pill full-width con prompt `$ mailto:_` en cyan, email grande, tag `booking · prensa · management`, flecha con transición al hover. Chamfer cyberpunk en las esquinas.
  2. **Grid de 4 social cards**: Instagram / YouTube / Spotify / Linktree con icono grande, nombre y handle. Borde accent que se expande al hover + glow en el icono.
  3. **Footnote discreto** con link a Nomios AI (reemplaza el botón suelto que antes quedaba flotando).
- Responsive: 4 cols → 2 cols en tablet → 2 cols compactas en mobile.

### Page glitch global
- Cada 9-22 segundos la página entera parpadea 620ms con `transform`, `hue-rotate` y `saturate` + overlay de scanlines cyan/magenta con `mix-blend-mode: screen`.
- 25% de las veces hay un segundo glitch 900ms después (efecto 'la realidad falla').
- Respeta `prefers-reduced-motion: reduce`.

## Test plan
- [ ] Desktop (≥1280px): hero title en 2 líneas, no desborda
- [ ] Contacto: 4 social cards en fila, email CTA bien legible, hover en cards
- [ ] Mobile: social grid colapsa a 2 cols, CTA email legible
- [ ] Esperar ~15s en cualquier sección → aparece glitch global
- [ ] Con `prefers-reduced-motion` activado no hay glitch

🤖 Generated with [Claude Code](https://claude.com/claude-code)