### PR TITLE
heo v2: centrar pulse del FAB sobre el icono

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1796,6 +1796,8 @@ body.is-glitching::after {
 }
 .lab-fab__pulse {
   position: absolute;
+  left: 0.7rem;
+  top: 0.7rem;
   width: 42px; height: 42px;
   border-radius: 50%;
   background: var(--fab-red);
@@ -1803,7 +1805,6 @@ body.is-glitching::after {
   animation: lab-pulse 2.4s ease-out infinite;
   pointer-events: none;
   z-index: -1;
-  margin: 0.7rem;
 }
 @keyframes lab-pulse {
   0%   { transform: scale(1);   opacity: 0.45; }


### PR DESCRIPTION
## Summary

El circulo que titila alrededor del icono de Nomios estaba corrido hacia la derecha.

Causa: `.lab-fab__pulse` tenia `position:absolute` sin `left/top`, con `margin:0.7rem`. En un padre flex con padding `0.7rem 1.1rem 0.7rem 0.7rem`, el elemento se posicionaba en la static position (tras el padding) y el margin sumaba otro 0.7rem, quedando descentrado.

Fix: `left:0.7rem; top:0.7rem` explicitos (mismo offset que el padding izq/sup del padre), sin margin. Asi el pulse cae exactamente sobre el icono.

## Test plan

- [ ] El pulse late centrado sobre el icono rojo del FAB
- [ ] Funciona igual en mobile (solo icono visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)