### PR TITLE
heo v2: pulse del FAB via box-shadow (centrado garantizado)

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1790,26 +1790,31 @@ body.is-glitching::after {
   background: radial-gradient(circle at 32% 28%, var(--fab-red), var(--fab-red-deep) 72%, var(--fab-red-dark));
   color: var(--fab-ink);
   flex-shrink: 0;
-  box-shadow:
-    0 0 12px rgba(225, 29, 46, 0.55),
-    inset 0 0 8px rgba(0, 0, 0, 0.55);
+  animation: lab-pulse-ring 2.4s ease-out infinite;
 }
-.lab-fab__pulse {
-  position: absolute;
-  left: 0.7rem;
-  top: 0.7rem;
-  width: 42px; height: 42px;
-  border-radius: 50%;
-  background: var(--fab-red);
-  opacity: 0.45;
-  animation: lab-pulse 2.4s ease-out infinite;
-  pointer-events: none;
-  z-index: -1;
-}
-@keyframes lab-pulse {
-  0%   { transform: scale(1);   opacity: 0.45; }
-  70%  { transform: scale(1.9); opacity: 0; }
-  100% { transform: scale(1.9); opacity: 0; }
+/* pulse ahora nace directamente del ícono via box-shadow, garantizando centrado.
+   El ::before ya no se usa — ocultamos el span legacy. */
+.lab-fab__pulse { display: none; }
+
+@keyframes lab-pulse-ring {
+  0% {
+    box-shadow:
+      0 0 0 0     rgba(225, 29, 46, 0.55),
+      0 0 12px    rgba(225, 29, 46, 0.55),
+      inset 0 0 8px rgba(0, 0, 0, 0.55);
+  }
+  70% {
+    box-shadow:
+      0 0 0 18px  rgba(225, 29, 46, 0),
+      0 0 12px    rgba(225, 29, 46, 0.55),
+      inset 0 0 8px rgba(0, 0, 0, 0.55);
+  }
+  100% {
+    box-shadow:
+      0 0 0 18px  rgba(225, 29, 46, 0),
+      0 0 12px    rgba(225, 29, 46, 0.55),
+      inset 0 0 8px rgba(0, 0, 0, 0.55);
+  }
 }
 .lab-fab__label {
   display: flex;


### PR DESCRIPTION
## Summary

El pulse del FAB seguia viendose corrido hacia la izquierda del icono (halo rojo escapandose por el borde del boton).

**Fix definitivo:** en vez de un `<span>` sibling posicionado con coordenadas que tienen que matchear el padding del padre, ahora el pulse nace del propio `box-shadow` del icono — ring spreading `0 -> 18px`. Garantiza centrado exacto sin mantener coordenadas sincronizadas.

- `.lab-fab__pulse` → `display:none` (el span legacy queda en el HTML)
- `@keyframes lab-pulse-ring` expande `box-shadow` del icono

## Test plan

- [ ] Scrollear fuera del hero: FAB aparece
- [ ] El halo rojo sale **simetricamente** alrededor del circulo del icono
- [ ] No se escapa por el borde izquierdo del boton

🤖 Generated with [Claude Code](https://claude.com/claude-code)