### PR TITLE
FAB: scroll listener más robusto (reemplaza IntersectionObserver)

### DIFF
--- a/js/heo-v2.js
+++ b/js/heo-v2.js
@@ -495,14 +495,16 @@ window.addEventListener('resize', () => {
   if (!fab) return;
 
   const hero = document.getElementById('inicio');
-  if (!hero) return;
 
-  const io = new IntersectionObserver((entries) => {
-    entries.forEach(e => {
-      /* Cuando el hero sale casi entero, mostramos el FAB */
-      fab.classList.toggle('is-visible', !e.isIntersecting);
-    });
-  }, { threshold: 0.15 });
+  function show() { fab.classList.add('is-visible'); }
+  function hide() { fab.classList.remove('is-visible'); }
 
-  io.observe(hero);
+  function update() {
+    if (!hero) { show(); return; }
+    const bottom = hero.getBoundingClientRect().bottom;
+    bottom < window.innerHeight * 0.15 ? show() : hide();
+  }
+
+  window.addEventListener('scroll', update, { passive: true });
+  update();
 })();


### PR DESCRIPTION
## Summary

- Reemplaza el `IntersectionObserver` del FAB por un `scroll` listener directo sobre `window`
- Se evalúa también al cargar la página (sin necesidad de hacer scroll primero)
- Fallback: si el hero `#inicio` no existe, muestra el FAB directamente

## Test plan

- [ ] Verificar que el FAB aparece al hacer scroll pasado el hero en `index_new.html`

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL