### PR TITLE
FAB: mejorar visibilidad del botón n0m10s

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1754,16 +1754,18 @@ body.is-glitching::after {
   align-items: center;
   gap: 0.75rem;
   padding: 0.7rem 1.1rem 0.7rem 0.7rem;
-  background: #050505;
-  border: 1px solid rgba(225, 29, 46, 0.55);
+  background: rgba(10, 10, 10, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1.5px solid rgba(225, 29, 46, 0.8);
   border-radius: 999px;
   color: var(--fab-ink);
   text-decoration: none;
   font-family: var(--font-mono);
   box-shadow:
     0 10px 36px rgba(0, 0, 0, 0.8),
-    0 0 16px rgba(225, 29, 46, 0.22),
-    inset 0 0 0 1px rgba(225, 29, 46, 0.08);
+    0 0 20px rgba(225, 29, 46, 0.35),
+    inset 0 0 0 1px rgba(225, 29, 46, 0.12);
   transform: translateY(120%) scale(0.85);
   opacity: 0;
   transition: transform 0.5s var(--ease-out), opacity 0.4s, box-shadow 0.4s, border-color 0.4s;


### PR DESCRIPTION
## Summary

- Border rojo más opaco (`0.8` en vez de `0.55`) y más grueso (`1.5px`)
- `backdrop-filter: blur(12px)` para separarse visualmente del fondo oscuro
- Glow rojo más intenso en el `box-shadow`

El problema: el fondo `#050505` era prácticamente invisible sobre la página oscura, haciendo que el botón pareciera texto suelto sin fondo.

## Test plan

- [ ] Verificar que el FAB se ve claramente como un botón al hacer scroll en `index_new.html`

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL