### PR TITLE
feat(share): texto mejorado, Orbitron, footer y CTA en sitio principal

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1014,6 +1014,37 @@ body::after {
 /* ============================================================
    FOOTER
    ============================================================ */
+.share-cta {
+  margin-top: 2.5rem;
+  padding: 1.8rem 2rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: rgba(34, 238, 201, 0.04);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.share-cta__label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.share-cta__text {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  max-width: 40ch;
+}
+
+.share-cta__btn {
+  margin-top: 0.25rem;
+}
+
 .site-footer {
   position: relative;
   z-index: 3;

--- a/index_new.html
+++ b/index_new.html
@@ -163,6 +163,14 @@
           </iframe>
         </div>
       </div>
+
+      <div class="share-cta reveal">
+        <p class="share-cta__label">// tu foto</p>
+        <p class="share-cta__text">Hacé tu foto con la estética del disco y compartila en redes.</p>
+        <a href="presentacion-album-mdufc/share.html" class="btn btn--solid share-cta__btn">
+          Crear imagen para redes →
+        </a>
+      </div>
     </div>
   </section>
 

--- a/presentacion-album-mdufc/css/share.css
+++ b/presentacion-album-mdufc/css/share.css
@@ -188,3 +188,26 @@
 	letter-spacing: 0.12em;
 	text-transform: uppercase;
 }
+
+.share-site-footer {
+	margin-top: 40px;
+	padding-top: 20px;
+	border-top: 1px solid rgba(34, 238, 201, 0.15);
+	text-align: center;
+}
+
+.share-site-footer__text {
+	font-size: 0.72rem;
+	color: var(--text-muted);
+	letter-spacing: 0.05em;
+	line-height: 1.6;
+}
+
+.share-site-footer__text strong {
+	color: rgba(255, 255, 255, 0.65);
+	font-weight: 500;
+}
+
+.share-site-footer__amp {
+	color: var(--accent);
+}

--- a/presentacion-album-mdufc/js/share-photo.js
+++ b/presentacion-album-mdufc/js/share-photo.js
@@ -290,7 +290,7 @@
 
 	function drawBranding() {
 		var logoSize = 112;
-		var pad = 36;
+		var pad = 56;
 		if (logoImg.complete && logoImg.naturalWidth > 0) {
 			ctx.save();
 			ctx.globalAlpha = 0.92;
@@ -301,20 +301,20 @@
 		}
 
 		ctx.save();
-		ctx.font = '500 32px "Space Grotesk", "Geist Mono", sans-serif';
+		ctx.font = '700 30px "Orbitron", "Space Grotesk", sans-serif';
 		ctx.fillStyle = "rgba(232, 232, 232, 0.92)";
 		ctx.shadowColor = "rgba(0,0,0,0.75)";
 		ctx.shadowBlur = 8;
 		ctx.shadowOffsetY = 2;
-		var text = "@heo.oficial";
+		var text = "@HEO.OFICIAL";
 		var tw = ctx.measureText(text).width;
-		ctx.fillText(text, OUT_W - tw - pad, OUT_H - pad);
+		ctx.fillText(text, OUT_W - tw - pad, OUT_H - pad - 10);
 
-		ctx.font = '22px "Geist Mono", monospace';
-		ctx.fillStyle = "rgba(34, 238, 201, 0.85)";
-		var sub = "Mitos de un futuro cercano";
+		ctx.font = '600 19px "Orbitron", "Space Grotesk", sans-serif';
+		ctx.fillStyle = "rgba(34, 238, 201, 0.88)";
+		var sub = "Mitos De Un Futuro Cercano";
 		var sw = ctx.measureText(sub).width;
-		ctx.fillText(sub, OUT_W - sw - pad, OUT_H - pad - 38);
+		ctx.fillText(sub, OUT_W - sw - pad, OUT_H - pad - 52);
 		ctx.restore();
 	}
 

--- a/presentacion-album-mdufc/share.html
+++ b/presentacion-album-mdufc/share.html
@@ -5,12 +5,12 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">
-	<title>Tu foto — Mitos de un futuro cercano · Hacia el Ocaso</title>
-	<meta name="description" content="Creá una imagen con glitch, colores del disco y marcas para compartir en redes.">
+	<title>Tu foto — Mitos de un Futuro Cercano · Hacia el Ocaso</title>
+	<meta name="description" content="Hacé tu foto con la estética del disco. Aplicá glitch, teñido y más efectos. Descargá lista para publicar.">
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
-	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Orbitron:wght@600;700&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="css/live.css?v=6">
-	<link rel="stylesheet" href="css/share.css?v=9">
+	<link rel="stylesheet" href="css/share.css?v=10">
 </head>
 <body class="share-page">
 	<div id="matrix-bg" aria-hidden="true">
@@ -23,13 +23,13 @@
 		</div>
 		<header class="share-intro">
 			<p class="kicker">Compartí</p>
-			<h1>Tu foto con el vibe del disco</h1>
-			<p class="sub">Subí una imagen: le sumamos color tapa y los FX que quieras. Listo para publicar.</p>
+			<h1>Tu foto con la estética del disco</h1>
+			<p class="sub">Cargá una imagen, combiná los FX y descargá. Todo corre en tu celular — nada se sube a ningún servidor.</p>
 		</header>
 		<div class="panel share-panel">
 			<label class="share-dropzone">
 				<span class="share-dropzone__label">Elegir foto</span>
-				<span class="share-dropzone__hint">JPG o PNG · se procesa en tu celular o PC, no la subimos a ningún servidor</span>
+				<span class="share-dropzone__hint">JPG o PNG · se procesa en tu celular o PC</span>
 				<input type="file" id="share-file" accept="image/*">
 			</label>
 			<div id="share-preview-wrap" class="share-preview-wrap hidden">
@@ -58,7 +58,13 @@
 				</p>
 			</div>
 		</div>
-		<a class="share-back" href="index.html">← Volver al show</a>
+		<a class="share-back" href="../index_new.html">← Volver al sitio</a>
+		<footer class="share-site-footer">
+			<p class="share-site-footer__text">
+				Hecho por <strong>Hacia el Ocaso</strong> &mdash;
+				mezclando máquinas <span class="share-site-footer__amp">&amp;</span> corazón humano.
+			</p>
+		</footer>
 	</div>
 	<script>
 	(function () {


### PR DESCRIPTION
## Cambios

### `share.html`
- Texto: H1 → "Tu foto con la estética del disco" / Sub más directo y claro
- Font Orbitron agregada (Google Fonts)
- Footer "Hecho por Hacia el Ocaso — mezclando máquinas & corazón humano"
- Link de retorno apunta a `../index_new.html` (sitio principal)

### `share-photo.js` — branding en imagen generada
- Padding aumentado a 56px → textos más arriba, no se cortan
- Font **Orbitron 700** para `@HEO.OFICIAL` y `Mitos De Un Futuro Cercano`
- Handle en mayúsculas: `@HEO.OFICIAL`
- Álbum en title case: `Mitos De Un Futuro Cercano`

### `index_new.html` + `heo-v2.css`
- CTA "Crear imagen para redes →" en la sección `#musica`, enlaza a `presentacion-album-mdufc/share.html`

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL