### PR TITLE
feat(share): botón Compartir via Web Share API

### DIFF
--- a/presentacion-album-mdufc/js/share-photo.js
+++ b/presentacion-album-mdufc/js/share-photo.js
@@ -416,6 +416,27 @@
 		});
 	}
 
+	var btnShare = document.getElementById("btn-share");
+	if (btnShare && navigator.canShare) {
+		/* Mostrar el botón solo si el navegador soporta compartir archivos */
+		var testFile = new File([""], "t.png", { type: "image/png" });
+		if (navigator.canShare({ files: [testFile] })) {
+			btnShare.hidden = false;
+		}
+		btnShare.addEventListener("click", function () {
+			if (!hasImage) return;
+			canvas.toBlob(function (blob) {
+				if (!blob) return;
+				var file = new File([blob], "hacia-el-ocaso-mitos.png", { type: "image/png" });
+				navigator.share({
+					files: [file],
+					title: "Mitos De Un Futuro Cercano — Hacia el Ocaso",
+					text: "Mi foto con la estética de @heo.oficial"
+				}).catch(function () {});
+			}, "image/png");
+		});
+	}
+
 	var fxPills = document.querySelectorAll(".fx-pill[data-fx]");
 	Array.prototype.forEach.call(fxPills, function (btn) {
 		btn.addEventListener("click", function () {

--- a/presentacion-album-mdufc/share.html
+++ b/presentacion-album-mdufc/share.html
@@ -50,7 +50,8 @@
 				</div>
 				<div class="share-actions">
 					<button type="button" class="btn" id="btn-shuffle">Otro glitch</button>
-					<button type="button" class="btn btn-primary-solid" id="btn-download">Descargar PNG</button>
+					<button type="button" class="btn btn-primary-solid" id="btn-share" hidden>Compartir</button>
+					<button type="button" class="btn" id="btn-download">Descargar PNG</button>
 				</div>
 				<p class="share-footer-note">
 					Instagram:


### PR DESCRIPTION
Agrega un botón **Compartir** que usa la [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API) para enviar la imagen generada directamente desde el navegador.

## Cómo funciona

- En **iOS/Android** abre el selector nativo del sistema: el usuario elige WhatsApp, Instagram, Telegram, Mensajes, etc. La imagen va directo, sin pasar por ningún servidor.
- En **desktop** (Chrome/Firefox donde la API no soporta archivos) el botón permanece oculto — el flujo de descarga sigue siendo el predeterminado.

## Detalle técnico

- El botón `#btn-share` arranca con `hidden`. Solo se muestra si `navigator.canShare({ files: [...] })` devuelve `true`.
- Al hacer click genera el blob del canvas y llama `navigator.share({ files, title, text })`.

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL