### PR TITLE
Experiencias, cancionero toggle, Poli IG, nav fix

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1045,6 +1045,62 @@ body::after {
   margin-top: 0.25rem;
 }
 
+/* Experiencias */
+.exp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.exp-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  text-decoration: none;
+  transition: border-color 0.3s, background 0.3s, transform 0.3s;
+}
+
+.exp-card:hover {
+  border-color: var(--accent);
+  background: rgba(34, 238, 201, 0.04);
+  transform: translateY(-2px);
+}
+
+.exp-card__tag {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent-dim);
+}
+
+.exp-card__title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.exp-card__desc {
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+  flex: 1;
+}
+
+.exp-card__cta {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  margin-top: 0.25rem;
+}
+
 .site-footer {
   position: relative;
   z-index: 3;
@@ -1266,7 +1322,7 @@ body::after {
   .nav__menu {
     position: fixed;
     inset: 0;
-    background: rgba(5, 5, 7, 0.97);
+    background: #050507;
     backdrop-filter: blur(28px);
     -webkit-backdrop-filter: blur(28px);
     flex-direction: column;

--- a/index_new.html
+++ b/index_new.html
@@ -17,7 +17,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@300;400;500&family=Orbitron:wght@500;600;700;800;900&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="css/heo-v2.css">
+  <link rel="stylesheet" href="css/heo-v2.css?v=2">
 
   <!-- Meta Pixel -->
   <script>
@@ -50,12 +50,13 @@
       </a>
 
       <ul class="nav__menu" id="nav-menu" role="list">
-        <li><a href="#musica"   class="nav__link">Música</a></li>
-        <li><a href="#shows"    class="nav__link">Shows</a></li>
-        <li><a href="#videos"   class="nav__link">Videos</a></li>
-        <li><a href="#galeria"  class="nav__link">Fotos</a></li>
-        <li><a href="#nosotros" class="nav__link">Nosotros</a></li>
-        <li><a href="#contacto" class="nav__link">Contacto</a></li>
+        <li><a href="#musica"        class="nav__link">Música</a></li>
+        <li><a href="#shows"         class="nav__link">Shows</a></li>
+        <li><a href="#experiencias"  class="nav__link">Experiencias</a></li>
+        <li><a href="#videos"        class="nav__link">Videos</a></li>
+        <li><a href="#galeria"       class="nav__link">Fotos</a></li>
+        <li><a href="#nosotros"      class="nav__link">Nosotros</a></li>
+        <li><a href="#contacto"      class="nav__link">Contacto</a></li>
       </ul>
 
       <button class="nav__burger" id="nav-burger"
@@ -259,6 +260,39 @@
 
 
   <!-- ======================================================
+       EXPERIENCIAS
+       ====================================================== -->
+  <section id="experiencias" class="section">
+    <div class="container">
+      <header class="section__header">
+        <span class="section__label">// vivilo</span>
+        <h2 class="section__title">Experiencias</h2>
+      </header>
+      <div class="exp-grid">
+        <a href="presentacion-album-mdufc/index.html" class="exp-card reveal">
+          <span class="exp-card__tag">// en vivo</span>
+          <h3 class="exp-card__title">Cancionero en vivo</h3>
+          <p class="exp-card__desc">Seguí el show en tiempo real. Letra e info de cada tema a medida que suenan.</p>
+          <span class="exp-card__cta">Ver cancionero →</span>
+        </a>
+        <a href="presentacion-album-mdufc/share.html" class="exp-card reveal">
+          <span class="exp-card__tag">// tu foto</span>
+          <h3 class="exp-card__title">Tu foto para redes</h3>
+          <p class="exp-card__desc">Aplicá la estética del disco en tu foto y descargala lista para publicar.</p>
+          <span class="exp-card__cta">Crear imagen →</span>
+        </a>
+        <a href="n0m10s/" class="exp-card reveal">
+          <span class="exp-card__tag">// ia</span>
+          <h3 class="exp-card__title">Nomios</h3>
+          <p class="exp-card__desc">Una IA entrenada en las letras del disco. Preguntale lo que quieras.</p>
+          <span class="exp-card__cta">Entrar →</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ======================================================
        VIDEOS
        ====================================================== -->
   <section id="videos" class="section">
@@ -452,14 +486,14 @@
           </div>
           <h3 class="member-card__name">Poli Abdusetir</h3>
           <p class="member-card__role">Bajo y voces</p>
-          <a href="https://www.instagram.com/kowalskiramiro"
+          <a href="https://www.instagram.com/loco_poli"
              class="member-card__ig"
              target="_blank" rel="noopener noreferrer"
              aria-label="Instagram de Poli Abdusetir">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
             </svg>
-            @kowalskiramiro
+            @loco_poli
           </a>
         </div>
 

--- a/nosotros.html
+++ b/nosotros.html
@@ -111,7 +111,7 @@
 									</div>
 									<div class="team-wrap row mt-4">
 										<div class="col-md-6 team">
-											<a href="https://www.instagram.com/kowalskiramiro">
+											<a href="https://www.instagram.com/loco_poli">
 												<div class="img" style="background-image: url(images/fotos.jpg);"></div>
 												<h3>Poli <br>Abdusetir</h3>
 												<span>Bajo y voces</span>

--- a/presentacion-album-mdufc/api/set.php
+++ b/presentacion-album-mdufc/api/set.php
@@ -52,7 +52,7 @@ $songs = isset($setlist['songs']) && is_array($setlist['songs']) ? $setlist['son
 $max = max(0, count($songs) - 1);
 
 $statePath = $root . '/data/state.json';
-$state = array('currentIndex' => 0, 'updatedAt' => 0);
+$state = array('currentIndex' => 0, 'updatedAt' => 0, 'enabled' => true);
 if (is_readable($statePath)) {
 	$prev = json_decode(file_get_contents($statePath), true);
 	if (is_array($prev)) {
@@ -62,6 +62,7 @@ if (is_readable($statePath)) {
 
 $idx = isset($state['currentIndex']) ? (int) $state['currentIndex'] : 0;
 $idx = max(0, min($max, $idx));
+$enabled = isset($state['enabled']) ? (bool) $state['enabled'] : true;
 
 switch ($action) {
 	case 'next':
@@ -73,6 +74,12 @@ switch ($action) {
 	case 'reset':
 		$idx = 0;
 		break;
+	case 'enable':
+		$enabled = true;
+		break;
+	case 'disable':
+		$enabled = false;
+		break;
 	default:
 		http_response_code(400);
 		echo json_encode(array('ok' => false, 'error' => 'bad_action'));
@@ -82,6 +89,7 @@ switch ($action) {
 $newState = array(
 	'currentIndex' => $idx,
 	'updatedAt' => time(),
+	'enabled' => $enabled,
 );
 
 $written = @file_put_contents($statePath, json_encode($newState, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . "\n");
@@ -95,4 +103,5 @@ echo json_encode(array(
 	'ok' => true,
 	'currentIndex' => $idx,
 	'updatedAt' => $newState['updatedAt'],
+	'enabled' => $enabled,
 ), JSON_UNESCAPED_UNICODE);

--- a/presentacion-album-mdufc/api/state.php
+++ b/presentacion-album-mdufc/api/state.php
@@ -9,6 +9,7 @@ if (!is_readable($path)) {
 	echo json_encode(array(
 		'currentIndex' => 0,
 		'updatedAt' => time(),
+		'enabled' => true,
 	), JSON_UNESCAPED_UNICODE);
 	exit;
 }
@@ -21,8 +22,10 @@ if (!is_array($data)) {
 
 $idx = isset($data['currentIndex']) ? (int) $data['currentIndex'] : 0;
 $updated = isset($data['updatedAt']) ? (int) $data['updatedAt'] : 0;
+$enabled = isset($data['enabled']) ? (bool) $data['enabled'] : true;
 
 echo json_encode(array(
 	'currentIndex' => $idx,
 	'updatedAt' => $updated,
+	'enabled' => $enabled,
 ), JSON_UNESCAPED_UNICODE);

--- a/presentacion-album-mdufc/css/live.css
+++ b/presentacion-album-mdufc/css/live.css
@@ -483,6 +483,60 @@ code {
 	display: none !important;
 }
 
+.inactive-panel {
+	text-align: center;
+	padding: 36px 24px;
+}
+
+.inactive__icon {
+	font-size: 2.5rem;
+	color: var(--accent-dim);
+	margin-bottom: 16px;
+	animation: pulse-icon 2.4s ease-in-out infinite;
+}
+
+@keyframes pulse-icon {
+	0%, 100% { opacity: 0.4; }
+	50% { opacity: 1; }
+}
+
+.inactive__title {
+	font-family: "Space Grotesk", sans-serif;
+	font-size: 1.25rem;
+	font-weight: 600;
+	color: var(--text);
+	margin-bottom: 12px;
+}
+
+.inactive__msg {
+	font-size: 0.88rem;
+	color: var(--text-muted);
+	line-height: 1.6;
+	margin-bottom: 28px;
+}
+
+.inactive__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	align-items: center;
+}
+
+.inactive__back {
+	margin-top: 28px;
+	font-size: 0.72rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+}
+
+.enabled-status {
+	font-weight: 600;
+	letter-spacing: 0.12em;
+}
+
+.enabled-status--on { color: var(--accent); }
+.enabled-status--off { color: #f0a0a8; }
+
 .dev-banner {
 	position: fixed;
 	bottom: 0;

--- a/presentacion-album-mdufc/css/share.css
+++ b/presentacion-album-mdufc/css/share.css
@@ -180,10 +180,16 @@
 	color: var(--accent);
 }
 
-.share-back {
-	display: block;
-	text-align: center;
+.share-back-links {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 8px 24px;
 	margin-top: 24px;
+}
+
+.share-back {
+	display: inline-block;
 	font-size: 0.75rem;
 	letter-spacing: 0.12em;
 	text-transform: uppercase;

--- a/presentacion-album-mdufc/data/state.json
+++ b/presentacion-album-mdufc/data/state.json
@@ -1,4 +1,5 @@
 {
   "currentIndex": 0,
-  "updatedAt": 0
+  "updatedAt": 0,
+  "enabled": true
 }

--- a/presentacion-album-mdufc/index.html
+++ b/presentacion-album-mdufc/index.html
@@ -8,7 +8,7 @@
 	<title>Mitos de un futuro cercano — Hacia el Ocaso</title>
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/live.css?v=6">
+	<link rel="stylesheet" href="css/live.css?v=7">
 </head>
 <body>
 	<div id="matrix-bg" aria-hidden="true">
@@ -19,6 +19,27 @@
 		<div class="brand-mark">
 			<img src="../images/ojo-goth-blanco.png" alt="Hacia el Ocaso" class="brand-mark__img" width="72" height="72" decoding="async">
 		</div>
+		<div id="view-inactive" class="hidden">
+			<div class="panel inactive-panel">
+				<p class="inactive__icon" aria-hidden="true">◌</p>
+				<h2 class="inactive__title">Sin evento activo</h2>
+				<p class="inactive__msg">No hay cancionero en vivo en este momento.<br>Volvé cuando haya show.</p>
+				<div class="inactive__actions">
+					<a href="https://tickets.latangente.com.ar/musica/hacia-el-ocaso"
+					   class="btn btn-primary-solid"
+					   target="_blank" rel="noopener noreferrer">
+						Conseguir entradas →
+					</a>
+					<a href="https://www.instagram.com/heo.oficial"
+					   class="btn btn-ghost"
+					   target="_blank" rel="noopener noreferrer">
+						Seguirnos en Instagram
+					</a>
+				</div>
+				<p class="inactive__back"><a href="../index_new.html">← Volver al sitio</a></p>
+			</div>
+		</div>
+
 		<div id="view-list">
 			<header class="header-block">
 				<p class="kicker" id="meta-event">En vivo</p>

--- a/presentacion-album-mdufc/js/app.js
+++ b/presentacion-album-mdufc/js/app.js
@@ -11,6 +11,7 @@
 	var state = {
 		setlist: null,
 		currentIndex: 0,
+		enabled: true,
 		devMode: false,
 		pollTimer: null,
 		lastError: null,
@@ -94,6 +95,7 @@
 				var idx = parseInt(data.currentIndex, 10);
 				if (isNaN(idx)) idx = 0;
 				state.currentIndex = idx;
+				state.enabled = data.enabled !== false;
 				state.lastError = null;
 				render();
 			})
@@ -111,7 +113,18 @@
 		}
 	}
 
+	function renderInactive() {
+		var listEl = $("#view-list");
+		var detailEl = $("#view-detail");
+		var inactiveEl = $("#view-inactive");
+		if (listEl) listEl.classList.add("hidden");
+		if (detailEl) detailEl.classList.add("hidden");
+		if (inactiveEl) inactiveEl.classList.remove("hidden");
+	}
+
 	function renderList() {
+		var inactiveEl = $("#view-inactive");
+		if (inactiveEl) inactiveEl.classList.add("hidden");
 		var listEl = $("#view-list");
 		var detailEl = $("#view-detail");
 		if (!listEl || !detailEl) return;
@@ -241,6 +254,10 @@
 
 	function render() {
 		if (!state.setlist) return;
+		if (!state.enabled) {
+			renderInactive();
+			return;
+		}
 		var songs = state.setlist.songs || [];
 		var max = Math.max(0, songs.length - 1);
 		state.currentIndex = Math.min(Math.max(0, state.currentIndex), max);

--- a/presentacion-album-mdufc/js/operator.js
+++ b/presentacion-album-mdufc/js/operator.js
@@ -20,6 +20,7 @@
 	var state = {
 		setlist: null,
 		currentIndex: 0,
+		enabled: true,
 		devMode: false,
 	};
 
@@ -55,6 +56,23 @@
 		var s = songs[state.currentIndex];
 		el.textContent = s ? s.title : "—";
 		$("#preview-index").textContent = String(state.currentIndex + 1) + " / " + songs.length;
+		var toggleBtn = $("#btn-toggle");
+		if (toggleBtn) {
+			if (state.enabled) {
+				toggleBtn.textContent = "Desactivar cancionero";
+				toggleBtn.classList.remove("btn-primary-solid");
+				toggleBtn.classList.add("btn-ghost");
+			} else {
+				toggleBtn.textContent = "Activar cancionero";
+				toggleBtn.classList.add("btn-primary-solid");
+				toggleBtn.classList.remove("btn-ghost");
+			}
+		}
+		var statusEnabled = $("#enabled-status");
+		if (statusEnabled) {
+			statusEnabled.textContent = state.enabled ? "ACTIVO" : "INACTIVO";
+			statusEnabled.className = "enabled-status " + (state.enabled ? "enabled-status--on" : "enabled-status--off");
+		}
 	}
 
 	function setStatus(msg, isErr) {
@@ -73,6 +91,8 @@
 			if (action === "next") idx = Math.min(max, idx + 1);
 			else if (action === "prev") idx = Math.max(0, idx - 1);
 			else if (action === "reset") idx = 0;
+			else if (action === "enable") state.enabled = true;
+			else if (action === "disable") state.enabled = false;
 			localStorage.setItem(STORAGE_DEV, String(idx));
 			state.currentIndex = idx;
 			updatePreview();
@@ -104,11 +124,13 @@
 					throw new Error(err);
 				}
 				state.currentIndex = res.data.currentIndex;
+				state.enabled = res.data.enabled !== false;
 				try {
 					sessionStorage.setItem(STORAGE_SECRET, secret);
 				} catch (e) {}
 				updatePreview();
-				setStatus("Listo · índice " + state.currentIndex, false);
+				var label = state.enabled ? "activo" : "inactivo";
+				setStatus("Listo · índice " + state.currentIndex + " · cancionero " + label, false);
 			})
 			.catch(function (e) {
 				setStatus(e.message || "Falló la petición.", true);
@@ -133,8 +155,10 @@
 				var idx = parseInt(data.currentIndex, 10);
 				if (isNaN(idx)) idx = 0;
 				state.currentIndex = Math.min(Math.max(0, idx), maxIndex());
+				state.enabled = data.enabled !== false;
 				updatePreview();
-				setStatus("Estado remoto: índice " + state.currentIndex, false);
+				var label = state.enabled ? "activo" : "inactivo";
+				setStatus("Estado remoto: índice " + state.currentIndex + " · cancionero " + label, false);
 			})
 			.catch(function () {
 				setStatus("No se pudo leer api/state.php (¿servidor PHP local?)", true);
@@ -170,6 +194,7 @@
 				var idx = parseInt(data.currentIndex, 10);
 				if (isNaN(idx)) idx = 0;
 				state.currentIndex = Math.min(Math.max(0, idx), maxIndex());
+				state.enabled = data.enabled !== false;
 				updatePreview();
 				setStatus("Conectado.", false);
 			})
@@ -187,6 +212,13 @@
 			if (window.confirm("¿Volver al inicio del set (índice 0)?")) sendAction("reset");
 		});
 		$("#btn-refresh").addEventListener("click", syncFromServer);
+		$("#btn-toggle").addEventListener("click", function () {
+			var action = state.enabled ? "disable" : "enable";
+			var msg = state.enabled
+				? "¿Desactivar el cancionero? El público verá \"Sin evento activo\"."
+				: "¿Activar el cancionero?";
+			if (window.confirm(msg)) sendAction(action);
+		});
 	}
 
 	if (document.readyState === "loading") {

--- a/presentacion-album-mdufc/operator.html
+++ b/presentacion-album-mdufc/operator.html
@@ -8,7 +8,7 @@
 	<title>Operador — Mitos de un futuro cercano</title>
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/live.css?v=6">
+	<link rel="stylesheet" href="css/live.css?v=7">
 </head>
 <body>
 	<div id="matrix-bg" aria-hidden="true">
@@ -44,6 +44,12 @@
 				<button type="button" class="btn btn-ghost" id="btn-reset">Ir al inicio</button>
 				<button type="button" class="btn btn-ghost" id="btn-refresh">Refrescar estado</button>
 			</div>
+			<div class="operator-actions" style="margin-top:16px;">
+				<button type="button" class="btn btn-ghost" id="btn-toggle">Desactivar cancionero</button>
+			</div>
+			<p style="text-align:center;margin-top:10px;font-size:0.7rem;letter-spacing:0.18em;text-transform:uppercase;">
+				Estado: <span id="enabled-status" class="enabled-status enabled-status--on">ACTIVO</span>
+			</p>
 
 			<p class="status-bar" id="operator-status"></p>
 		</div>

--- a/presentacion-album-mdufc/share.html
+++ b/presentacion-album-mdufc/share.html
@@ -9,8 +9,8 @@
 	<meta name="description" content="Hacé tu foto con la estética del disco. Aplicá glitch, teñido y más efectos. Descargá lista para publicar.">
 	<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 	<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Orbitron:wght@600;700&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/live.css?v=6">
-	<link rel="stylesheet" href="css/share.css?v=10">
+	<link rel="stylesheet" href="css/live.css?v=7">
+	<link rel="stylesheet" href="css/share.css?v=11">
 </head>
 <body class="share-page">
 	<div id="matrix-bg" aria-hidden="true">
@@ -24,7 +24,7 @@
 		<header class="share-intro">
 			<p class="kicker">Compartí</p>
 			<h1>Tu foto con la estética del disco</h1>
-			<p class="sub">Cargá una imagen, combiná los FX y descargá. Todo corre en tu celular — nada se sube a ningún servidor.</p>
+			<p class="sub">Cargá una imagen, combiná los FX y descargá. Todo corre en tu dispositivo — nada se sube a ningún servidor.</p>
 		</header>
 		<div class="panel share-panel">
 			<label class="share-dropzone">
@@ -59,7 +59,10 @@
 				</p>
 			</div>
 		</div>
-		<a class="share-back" href="../index_new.html">← Volver al sitio</a>
+		<div class="share-back-links">
+			<a class="share-back" href="index.html">← Volver al show</a>
+			<a class="share-back" href="../index_new.html">← Volver al sitio oficial</a>
+		</div>
 		<footer class="share-site-footer">
 			<p class="share-site-footer__text">
 				Hecho por <strong>Hacia el Ocaso</strong> &mdash;


### PR DESCRIPTION
## Summary

- **IG de Poli**: actualizado a `@loco_poli` en `nosotros.html` e `index_new.html`
- **share.html**: "celular" → "dispositivo" + dos links de vuelta (Volver al show / Volver al sitio oficial)
- **Nav mobile**: fondo cambiado a `#050507` sólido (fix del menú con fondo transparente)
- **Sección Experiencias**: nueva sección en `index_new.html` con tarjetas para Cancionero en vivo, Tu foto para redes y Nomios; nuevo ítem en el nav
- **Toggle del cancionero**: el operador puede activar/desactivar el cancionero desde `operator.html`; cuando está inactivo, el público ve una pantalla con mensaje + CTA de entradas + seguir en IG

## Archivos cambiados

| Archivo | Qué cambió |
|---|---|
| `nosotros.html` | IG Poli → `@loco_poli` |
| `index_new.html` | IG Poli, sección Experiencias, nav item, cache-bust CSS |
| `css/heo-v2.css` | Nav mobile bg sólido + estilos `.exp-card` |
| `presentacion-album-mdufc/share.html` | "dispositivo", dos back links, bump CSS version |
| `presentacion-album-mdufc/css/share.css` | Estilos `.share-back-links` |
| `presentacion-album-mdufc/css/live.css` | Estilos pantalla inactiva + badge ACTIVO/INACTIVO |
| `presentacion-album-mdufc/index.html` | Vista `#view-inactive` con CTA entradas e IG |
| `presentacion-album-mdufc/operator.html` | Botón toggle + indicador de estado |
| `presentacion-album-mdufc/js/app.js` | Lee `enabled`, muestra `#view-inactive` cuando false |
| `presentacion-album-mdufc/js/operator.js` | Acción toggle, estado enabled en preview |
| `presentacion-album-mdufc/api/state.php` | Devuelve campo `enabled` |
| `presentacion-album-mdufc/api/set.php` | Acepta acciones `enable` / `disable` |
| `presentacion-album-mdufc/data/state.json` | Agrega `"enabled": true` |

## Test plan

- [ ] En mobile, abrir menú hamburguesa → fondo debe ser negro sólido
- [ ] Verificar que `@loco_poli` aparece en nosotros.html y en la sección Nosotros de index_new.html
- [ ] En share.html, verificar que dice "dispositivo" y que aparecen ambos links de vuelta
- [ ] Sección Experiencias visible en index_new.html con las 3 tarjetas; nav link "Experiencias" funciona
- [ ] En operator.html, botón "Desactivar cancionero" → confirmar → badge cambia a INACTIVO
- [ ] En index.html (cancionero público), recargar → debe mostrar pantalla "Sin evento activo" con CTA de entradas e IG
- [ ] Reactivar desde operator.html → cancionero vuelve a funcionar normalmente

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL