### PR TITLE
Fix IG/YouTube handles + ASCII FX brightness

### DIFF
--- a/index_new.html
+++ b/index_new.html
@@ -551,7 +551,7 @@
       <!-- Grid de redes sociales -->
       <div class="social-grid reveal" role="list">
 
-        <a href="https://www.instagram.com/haciaelocaso"
+        <a href="https://www.instagram.com/heo.oficial"
            class="social-card"
            target="_blank" rel="noopener noreferrer"
            role="listitem"
@@ -560,10 +560,10 @@
             <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
           </svg>
           <span class="social-card__name">Instagram</span>
-          <span class="social-card__handle">@haciaelocaso</span>
+          <span class="social-card__handle">@heo.oficial</span>
         </a>
 
-        <a href="https://www.youtube.com/@haciaelocaso"
+        <a href="https://youtube.com/@heo.oficial?si=mq6pF5UyD4K3u-4Y"
            class="social-card"
            target="_blank" rel="noopener noreferrer"
            role="listitem"
@@ -572,7 +572,7 @@
             <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
           </svg>
           <span class="social-card__name">YouTube</span>
-          <span class="social-card__handle">@haciaelocaso</span>
+          <span class="social-card__handle">@heo.oficial</span>
         </a>
 
         <a href="https://open.spotify.com/playlist/6So94YyGUL4HI45JjLzbAp"

--- a/presentacion-album-mdufc/js/share-photo.js
+++ b/presentacion-album-mdufc/js/share-photo.js
@@ -281,7 +281,7 @@
 		ctx.font = cellH + 'px "Geist Mono", monospace';
 		ctx.textBaseline = "top";
 
-		var row, col, r, g, b, ch, lumN;
+		var row, col, r, g, b, ch, lumN, rb, gb, bb;
 		for (row = 0; row < rows; row++) {
 			for (col = 0; col < cols; col++) {
 				i = (row * cols + col) * 4;
@@ -291,10 +291,15 @@
 				lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
 				lumN = (lum - lumMin) / lumRange;
 				ch = chars[Math.round(lumN * last)];
-				r = Math.min(255, Math.round(r * 2.2));
-				g = Math.min(255, Math.round(g * 2.2));
-				b = Math.min(255, Math.round(b * 2.2));
-				ctx.fillStyle = "rgb(" + r + "," + g + "," + b + ")";
+				rb = Math.min(255, Math.round(r * 2.2));
+				gb = Math.min(255, Math.round(g * 2.2));
+				bb = Math.min(255, Math.round(b * 2.2));
+				/* Fondo de celda: versión atenuada del color para que los
+				   huecos entre caracteres no sean negro puro */
+				ctx.fillStyle = "rgb(" + Math.round(rb * 0.28) + "," + Math.round(gb * 0.28) + "," + Math.round(bb * 0.28) + ")";
+				ctx.fillRect(col * cellW, row * cellH, cellW, cellH);
+				/* Caracter en el color boosteado */
+				ctx.fillStyle = "rgb(" + rb + "," + gb + "," + bb + ")";
 				ctx.fillText(ch, col * cellW, row * cellH);
 			}
 		}


### PR DESCRIPTION
## Summary

- **IG y YouTube a @heo.oficial**: actualiza los links en la sección Contacto de `index_new.html`
- **ASCII FX más brillante**: los huecos entre caracteres ya no son negro puro

## Detalle

### IG / YouTube
- Instagram: `haciaelocaso` → `heo.oficial`
- YouTube: `haciaelocaso` → `heo.oficial` con URL nueva

### ASCII brightness fix
Los caracteres solo cubren ~65% de cada celda; el área restante era fondo `#050810` negro, haciendo que la foto resultante se vea muy oscura incluso en zonas brillantes. Ahora cada celda se pre-rellena con el 28% del color boosteado del pixel antes de dibujar el caracter, preservando el tono de esa zona.

## Test plan
- [ ] Sección Contacto de `index_new.html`: verificar que IG dice `@heo.oficial` y YouTube abre el canal correcto
- [ ] En `share.html`, activar el FX ASCII → la foto debe verse con brillo comparable al resto de los FX, sin oscurecerse drásticamente

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL