### PR TITLE
Fix player logo aspect ratio + expand footer

### DIFF
--- a/album.html
+++ b/album.html
@@ -17,7 +17,7 @@
   <div class="player-wrap">
 
     <div class="player-header">
-      <img src="images/ojo-goth-blanco.png" alt="" class="player-logo" width="48" height="48" aria-hidden="true">
+      <img src="images/ojo-goth-blanco.png" alt="" class="player-logo" aria-hidden="true">
     </div>
 
     <!-- ═══════════════════════════════════════
@@ -112,6 +112,19 @@
       <p class="player-footer__hint">
         ▶ Sigue sonando con la <span>pantalla apagada</span>
       </p>
+
+      <div class="player-footer__socials">
+        <a href="https://www.instagram.com/heo.oficial" class="player-footer__social" target="_blank" rel="noopener noreferrer">IG @heo.oficial</a>
+        <span class="player-footer__dot" aria-hidden="true">·</span>
+        <a href="https://youtube.com/@heo.oficial?si=mq6pF5UyD4K3u-4Y" class="player-footer__social" target="_blank" rel="noopener noreferrer">YT @heo.oficial</a>
+      </div>
+
+      <p class="player-footer__manifesto">
+        Hecho por <strong>Hacia el Ocaso</strong> &mdash; mezclando máquinas <span aria-hidden="true">&amp;</span> corazón humano.
+      </p>
+
+      <p class="player-footer__copy">&copy; 2026 HEO</p>
+
       <a href="index_new.html" class="player-footer__back">← Volver al sitio</a>
     </footer>
 

--- a/css/player.css
+++ b/css/player.css
@@ -63,6 +63,8 @@ body::before {
 }
 
 .player-logo {
+  height: 48px;
+  width: auto;
   opacity: 0.85;
   filter: drop-shadow(0 0 16px rgba(34, 238, 201, 0.4));
 }
@@ -417,7 +419,11 @@ body::before {
   text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  align-items: center;
+  gap: 12px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(34, 238, 201, 0.08);
+  width: 100%;
 }
 
 .player-footer__hint {
@@ -428,6 +434,45 @@ body::before {
 
 .player-footer__hint span {
   color: rgba(34, 238, 201, 0.55);
+}
+
+.player-footer__socials {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.player-footer__social {
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  color: rgba(34, 238, 201, 0.45);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.player-footer__social:hover { color: #22eec9; }
+
+.player-footer__dot {
+  font-size: 0.55rem;
+  color: rgba(34, 238, 201, 0.2);
+}
+
+.player-footer__manifesto {
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  color: rgba(232, 232, 232, 0.25);
+  line-height: 1.6;
+}
+
+.player-footer__manifesto strong {
+  color: rgba(232, 232, 232, 0.4);
+  font-weight: 600;
+}
+
+.player-footer__copy {
+  font-size: 0.55rem;
+  letter-spacing: 0.15em;
+  color: rgba(34, 238, 201, 0.18);
 }
 
 .player-footer__back {


### PR DESCRIPTION
## Summary
- Fix eye logo squished horizontally: remove hardcoded `width="48"` HTML attr, use CSS `height: 48px; width: auto` so it scales proportionally
- Replace minimal player footer with full footer: screen-off hint → IG + YT social links → band manifesto → copyright → back-to-site link

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL