### PR TITLE
Player logo fix + footer + matrix rain background

### DIFF
--- a/album.html
+++ b/album.html
@@ -14,6 +14,8 @@
 </head>
 <body>
 
+  <canvas id="matrix-rain" aria-hidden="true"></canvas>
+
   <div class="player-wrap">
 
     <div class="player-header">

--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1046,6 +1046,24 @@ body::after {
 }
 
 /* Experiencias */
+.exp-section {
+  position: relative;
+  overflow: hidden;
+}
+
+#exp-matrix {
+  position: absolute;
+  inset: 0;
+  display: block;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.exp-section .container {
+  position: relative;
+  z-index: 1;
+}
+
 .exp-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/css/player.css
+++ b/css/player.css
@@ -412,6 +412,15 @@ body::before {
   flex-shrink: 0;
 }
 
+/* ── Matrix rain background canvas ──── */
+#matrix-rain {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  display: block;
+}
+
 /* ══════════════════════════════════════
    FOOTER
 ══════════════════════════════════════ */
@@ -420,9 +429,9 @@ body::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
-  padding-top: 4px;
-  border-top: 1px solid rgba(34, 238, 201, 0.08);
+  gap: 14px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(34, 238, 201, 0.1);
   width: 100%;
 }
 

--- a/index_new.html
+++ b/index_new.html
@@ -261,7 +261,8 @@
   <!-- ======================================================
        EXPERIENCIAS
        ====================================================== -->
-  <section id="experiencias" class="section">
+  <section id="experiencias" class="section exp-section">
+    <canvas id="exp-matrix" aria-hidden="true"></canvas>
     <div class="container">
       <header class="section__header">
         <span class="section__label">// vivilo</span>

--- a/js/heo-v2.js
+++ b/js/heo-v2.js
@@ -508,3 +508,49 @@ window.addEventListener('resize', () => {
   window.addEventListener('scroll', update, { passive: true });
   update();
 })();
+
+
+/* ============================================================
+   EXPERIENCIAS — MATRIX RAIN BACKGROUND
+   Cae sobre el fondo de la sección, detrás de las tarjetas
+   ============================================================ */
+(function initExpMatrix() {
+  const el = document.getElementById('exp-matrix');
+  if (!el) return;
+  const ctx   = el.getContext('2d');
+  const CHARS = 'アイウエオカキクケコサシスセソタチツテトナニヌネノ01ムメモヤユヨ10';
+  const FS    = 11;
+  let drops   = [];
+
+  function resize() {
+    el.width  = el.offsetWidth;
+    el.height = el.offsetHeight;
+    const cols = Math.floor(el.width / FS);
+    while (drops.length < cols) drops.push(Math.random() * -40);
+    drops.length = cols;
+  }
+
+  window.addEventListener('resize', () => {
+    clearTimeout(el._rt);
+    el._rt = setTimeout(resize, 150);
+  });
+  resize();
+
+  function tick() {
+    ctx.fillStyle = 'rgba(5,5,7,0.08)';
+    ctx.fillRect(0, 0, el.width, el.height);
+    ctx.font = FS + "px 'Courier New', monospace";
+    for (let i = 0; i < drops.length; i++) {
+      const ch = CHARS[Math.floor(Math.random() * CHARS.length)];
+      const y  = Math.floor(drops[i]) * FS;
+      ctx.fillStyle = y < FS * 2
+        ? 'rgba(200,255,245,0.4)'
+        : 'rgba(34,238,201,0.09)';
+      ctx.fillText(ch, i * FS, y);
+      if (y > el.height && Math.random() > 0.974) drops[i] = 0;
+      drops[i] += 0.35;
+    }
+    requestAnimationFrame(tick);
+  }
+  tick();
+})();

--- a/js/player.js
+++ b/js/player.js
@@ -381,6 +381,50 @@
   if (btnNext) btnNext.addEventListener("click", goNext);
 
   /* ═══════════════════════════════════════════════════════════════
+     MATRIX RAIN BACKGROUND
+  ═══════════════════════════════════════════════════════════════ */
+  (function initMatrixRain() {
+    var el = document.getElementById("matrix-rain");
+    if (!el) return;
+    var rCtx  = el.getContext("2d");
+    var CHARS = "アイウエオカキクケコサシスセソタチツテトナニヌネノ01ムメモヤユヨ10";
+    var FS    = 11;
+    var drops = [];
+
+    function resizeMR() {
+      el.width  = window.innerWidth;
+      el.height = window.innerHeight;
+      var cols  = Math.floor(el.width / FS);
+      while (drops.length < cols) drops.push(Math.random() * -60);
+      drops.length = cols;
+    }
+
+    window.addEventListener("resize", function () {
+      clearTimeout(el._rt);
+      el._rt = setTimeout(resizeMR, 150);
+    });
+    resizeMR();
+
+    function tickMR() {
+      rCtx.fillStyle = "rgba(5,5,7,0.065)";
+      rCtx.fillRect(0, 0, el.width, el.height);
+      rCtx.font = FS + "px 'Courier New', monospace";
+      for (var i = 0; i < drops.length; i++) {
+        var ch = CHARS[Math.floor(Math.random() * CHARS.length)];
+        var y  = Math.floor(drops[i]) * FS;
+        rCtx.fillStyle = y < FS * 2
+          ? "rgba(200,255,245,0.55)"
+          : "rgba(34,238,201,0.13)";
+        rCtx.fillText(ch, i * FS, y);
+        if (y > el.height && Math.random() > 0.974) drops[i] = 0;
+        drops[i] += 0.4;
+      }
+      requestAnimationFrame(tickMR);
+    }
+    tickMR();
+  }());
+
+  /* ═══════════════════════════════════════════════════════════════
      INIT
   ═══════════════════════════════════════════════════════════════ */
   function init() {


### PR DESCRIPTION
## Summary
- Fix eye logo squished horizontally: CSS `height: 48px; width: auto` en lugar de atributos HTML fijos
- Expand player footer: hint de pantalla apagada → links IG + YT → manifesto → copyright → volver al sitio
- Matrix rain background en el reproductor (`album.html`): canvas fijo detrás del widget con caracteres katakana + números cayendo en teal
- Matrix rain background en la sección Experiencias (`index_new.html`): misma lluvia recortada a la sección, opacidad más suave para no tapar las tarjetas

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_