### PR TITLE
Fix contact section layout on mobile

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1006,8 +1006,23 @@ body::after {
 @media (max-width: 480px) {
   .social-grid { grid-template-columns: 1fr 1fr; gap: 0.75rem; }
   .social-card { min-height: 120px; padding: 1.1rem 1rem; }
-  .contact-hero__email { font-size: 1.15rem; }
   .contact-hero__prompt { display: none; }
+  .contact-hero {
+    padding: 1.2rem 1.25rem;
+    gap: 0.5rem 0.75rem;
+    align-items: center;
+  }
+  .contact-hero__email {
+    font-size: 1rem;
+    order: 1;
+    flex: 1;
+    min-width: 0;
+  }
+  .contact-hero__arrow { order: 2; flex-shrink: 0; }
+  .contact-hero__tag {
+    order: 3;
+    flex-basis: 100%;
+  }
 }
 
 


### PR DESCRIPTION
## Summary

- Fixes the contact hero block on mobile where the email was being crushed to 1–2 characters because the tag (`booking · prensa · management`) competed for horizontal space in the same row
- On ≤480px: email + arrow share row 1, tag drops to its own full-width row below

**Before:** `o.  BOOKING · PRENSA · MANAGEMENT  →`  
**After:** `ocasomcore@gmail.com  →`  
`booking · prensa · management`

## Test plan

- [ ] Open on iPhone (≤480px width) and verify the full email address is visible
- [ ] Check the tag appears below the email, full-width
- [ ] Verify desktop layout is unchanged

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_