### PR TITLE
Add Cae el velo as featured video

### DIFF
--- a/index_new.html
+++ b/index_new.html
@@ -310,11 +310,11 @@
 
       <!-- Video destacado -->
       <div class="video-featured reveal">
-        <span class="video-featured__tag" aria-hidden="true">FEATURED</span>
+        <span class="video-featured__tag" aria-hidden="true">NUEVO</span>
         <div class="video-card__embed">
           <iframe
-            src="https://www.youtube.com/embed/6GbiXOJ5zOQ?si=op-0OlrL-dKj-2f7"
-            title="Hacia el Ocaso — Video destacado"
+            src="https://www.youtube.com/embed/zXoY7GYSDX0?si=NWfJnQBM_jD2huw4"
+            title="Hacia el Ocaso — Cae el velo"
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen loading="lazy">
@@ -323,6 +323,17 @@
       </div>
 
       <div class="video-grid video-grid--small">
+        <div class="video-card reveal">
+          <div class="video-card__embed">
+            <iframe
+              src="https://www.youtube.com/embed/6GbiXOJ5zOQ?si=op-0OlrL-dKj-2f7"
+              title="Hacia el Ocaso — Video destacado"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen loading="lazy">
+            </iframe>
+          </div>
+        </div>
         <div class="video-card reveal">
           <div class="video-card__embed">
             <iframe


### PR DESCRIPTION
## Summary

- "Cae el velo" (`zXoY7GYSDX0`) reemplaza al video destacado (featured) como el lanzamiento más reciente, con badge `NUEVO`
- El video que era featured (6GbiXOJ5zOQ) baja al grid junto a los demás

## Test plan

- [ ] Verificar que "Cae el velo" aparece grande y primero en la sección Videos
- [ ] Verificar que el video anterior sigue visible en el grid de abajo
- [ ] Probar que el iframe reproduce correctamente

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_