### PR TITLE
Remove experiencias matrix canvas; fix Nomios FAB on mobile

### DIFF
--- a/css/heo-v2.css
+++ b/css/heo-v2.css
@@ -1046,23 +1046,6 @@ body::after {
 }
 
 /* Experiencias */
-.exp-section {
-  position: relative;
-  overflow: hidden;
-}
-
-#exp-matrix {
-  position: absolute;
-  inset: 0;
-  display: block;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.exp-section .container {
-  position: relative;
-  z-index: 1;
-}
 
 .exp-grid {
   display: grid;
@@ -1965,10 +1948,10 @@ body.is-glitching::after {
 }
 @media (max-width: 540px) {
   .lab-fab {
-    padding: 0.55rem;
-    gap: 0;
+    padding: 0.55rem 0.85rem 0.55rem 0.55rem;
+    gap: 0.4rem;
   }
-  .lab-fab__label { display: none; }
+  .lab-fab__text { display: none; }
 }
 .perf-lite .lab-fab__pulse { display: none; }
 .perf-lite .lab-fab__caret { animation: none; opacity: 1; }

--- a/index_new.html
+++ b/index_new.html
@@ -261,8 +261,7 @@
   <!-- ======================================================
        EXPERIENCIAS
        ====================================================== -->
-  <section id="experiencias" class="section exp-section">
-    <canvas id="exp-matrix" aria-hidden="true"></canvas>
+  <section id="experiencias" class="section">
     <div class="container">
       <header class="section__header">
         <span class="section__label">// vivilo</span>


### PR DESCRIPTION
## Summary

- **Experiencias**: elimina el `<canvas id="exp-matrix">` que aparecía como un rectángulo con caracteres en el sector superior izquierdo. El JS detecta que no existe el elemento y hace early-return sin error.
- **Nomios FAB mobile**: en ≤540px el label completo estaba oculto, dejando solo un ícono de terminal sin texto. Ahora muestra `> n0m10s` (kicker) y oculta solo la línea de texto larga.

**Antes (mobile):** `[⬡]` solo  
**Después (mobile):** `[⬡] > n0m10s`

## Test plan

- [ ] Verificar que la sección Experiencias ya no muestra el rectángulo con caracteres
- [ ] En mobile (≤540px), verificar que el botón rojo de Nomios muestra `> n0m10s` al scrollear
- [ ] En desktop, verificar que el botón Nomios sigue mostrando el texto completo

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_