### PR TITLE
folleto: remove album player item from extras

### DIFF
--- a/folleto.html
+++ b/folleto.html
@@ -456,7 +456,6 @@
       <div class="extras">
         <span class="extras__label">// más en haciaelocaso.com</span>
         <div class="extras__list">
-          <div class="extras__item"><span>▶</span> Escuchá el disco completo en el sitio</div>
           <div class="extras__item"><span>◈</span> Creá tu foto con la estética del álbum</div>
         </div>
       </div>


### PR DESCRIPTION
Removes "Escuchá el disco completo en el sitio" from the extras section, leaving only "Creá tu foto con la estética del álbum".

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_