### PR TITLE
folleto-doble: 2 folletos por página A4 horizontal

### DIFF
--- a/folleto-doble.html
+++ b/folleto-doble.html
@@ -1,0 +1,602 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Folleto Doble — Hacia el Ocaso</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@300;400;500&family=Orbitron:wght@500;600;700;800;900&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: #020204;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2.5rem 1rem;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      gap: 1.25rem;
+    }
+
+    .print-btn {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: rgba(34, 238, 201, 0.55);
+      background: transparent;
+      border: 1px solid rgba(34, 238, 201, 0.22);
+      border-radius: 3px;
+      padding: 0.55rem 1.4rem;
+      cursor: pointer;
+      transition: color 0.2s, border-color 0.2s;
+    }
+    .print-btn:hover { color: #22eec9; border-color: rgba(34, 238, 201, 0.55); }
+
+    /* Double layout */
+    .double-page {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      gap: 0;
+    }
+
+    /* Cut line between the two folletos */
+    .cut-line {
+      width: 1px;
+      align-self: stretch;
+      flex-shrink: 0;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(34,238,201,0.5) 0px, rgba(34,238,201,0.5) 6px,
+        transparent 6px, transparent 12px
+      );
+    }
+
+    /* ── Sheet ───────────────────────────────────── */
+    .sheet {
+      width: 600px;
+      min-height: 850px;
+      background: #050507;
+      position: relative;
+      overflow: hidden;
+      border: 1px solid rgba(34, 238, 201, 0.18);
+      box-shadow:
+        0 0 0 1px rgba(0,0,0,0.9),
+        0 0 80px rgba(34, 238, 201, 0.07),
+        0 40px 120px rgba(0,0,0,0.95);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 3rem 3.5rem 2.5rem;
+    }
+
+    /* Grid lines */
+    .sheet::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(34, 238, 201, 0.016) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(34, 238, 201, 0.016) 1px, transparent 1px);
+      background-size: 48px 48px;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    /* Scanlines */
+    .sheet::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: repeating-linear-gradient(
+        0deg, transparent, transparent 2px,
+        rgba(0,0,0,0.055) 2px, rgba(0,0,0,0.055) 4px
+      );
+      pointer-events: none;
+      z-index: 10;
+    }
+
+    /* Ambient glow top */
+    .glow {
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 340px;
+      background: radial-gradient(ellipse 90% 65% at 50% 0%,
+        rgba(34, 238, 201, 0.07), transparent 70%);
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    /* Corner brackets */
+    .corner {
+      position: absolute;
+      width: 20px;
+      height: 20px;
+      z-index: 6;
+    }
+    .corner--tl { top: 14px; left: 14px;
+      border-top: 1.5px solid rgba(34,238,201,0.7);
+      border-left: 1.5px solid rgba(34,238,201,0.7); }
+    .corner--tr { top: 14px; right: 14px;
+      border-top: 1.5px solid rgba(34,238,201,0.7);
+      border-right: 1.5px solid rgba(34,238,201,0.7); }
+    .corner--bl { bottom: 14px; left: 14px;
+      border-bottom: 1.5px solid rgba(34,238,201,0.7);
+      border-left: 1.5px solid rgba(34,238,201,0.7); }
+    .corner--br { bottom: 14px; right: 14px;
+      border-bottom: 1.5px solid rgba(34,238,201,0.7);
+      border-right: 1.5px solid rgba(34,238,201,0.7); }
+
+    /* ── Content ─────────────────────────────────────── */
+    .inner {
+      position: relative;
+      z-index: 2;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .logo {
+      width: 78px;
+      height: 78px;
+      object-fit: contain;
+      filter: drop-shadow(0 0 22px rgba(34, 238, 201, 0.45));
+      margin-bottom: 1.1rem;
+      margin-top: 0.25rem;
+    }
+
+    .band-eyebrow {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.58rem;
+      letter-spacing: 0.5em;
+      text-transform: uppercase;
+      color: rgba(34, 238, 201, 0.65);
+      margin-bottom: 0.55rem;
+    }
+
+    .band-name {
+      font-family: 'Orbitron', monospace;
+      font-size: 2.3rem;
+      font-weight: 800;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #e8e8e8;
+      text-shadow: 0 0 50px rgba(34, 238, 201, 0.22);
+      text-align: center;
+      line-height: 1;
+      margin-bottom: 1.6rem;
+    }
+
+    .divider {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 1.7rem;
+    }
+    .divider__line {
+      flex: 1;
+      height: 1px;
+      background: linear-gradient(90deg,
+        transparent,
+        rgba(34,238,201,0.28) 30%,
+        rgba(34,238,201,0.28) 70%,
+        transparent);
+    }
+    .divider__dot {
+      width: 4px; height: 4px;
+      border-radius: 50%;
+      background: #22eec9;
+      box-shadow: 0 0 10px rgba(34,238,201,0.9);
+      flex-shrink: 0;
+    }
+
+    .album-label {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.58rem;
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+      color: rgba(34, 238, 201, 0.5);
+      margin-bottom: 0.55rem;
+    }
+
+    .album-title {
+      font-size: 2rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: #e8e8e8;
+      text-align: center;
+      line-height: 1.18;
+      margin-bottom: 0.3rem;
+    }
+    .album-title em {
+      font-style: normal;
+      color: #22eec9;
+    }
+
+    .album-meta {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.22em;
+      color: rgba(232,232,232,0.55);
+      margin-bottom: 2rem;
+    }
+
+    .event-pill {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.58rem;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: #22eec9;
+      border: 1px solid rgba(34,238,201,0.28);
+      border-radius: 999px;
+      padding: 0.28rem 0.85rem;
+      margin-bottom: 0.85rem;
+    }
+
+    .event-heading {
+      font-family: 'Orbitron', monospace;
+      font-size: 1.1rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #e8e8e8;
+      text-align: center;
+      margin-bottom: 0.55rem;
+    }
+
+    .event-desc {
+      font-size: 0.9rem;
+      color: rgba(232,232,232,0.75);
+      text-align: center;
+      line-height: 1.65;
+      max-width: 300px;
+      margin-bottom: 2rem;
+    }
+
+    .qr-wrap {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.85rem;
+      margin-bottom: 1.6rem;
+    }
+
+    .qr-frame {
+      position: relative;
+      padding: 14px;
+      border: 1px solid rgba(34,238,201,0.22);
+      border-radius: 4px;
+      background: rgba(5,5,7,0.6);
+    }
+    .qr-frame::before,
+    .qr-frame::after,
+    .qr-frame .qr-corner-bl,
+    .qr-frame .qr-corner-tr {
+      content: '';
+      position: absolute;
+      width: 14px; height: 14px;
+    }
+    .qr-frame::before {
+      top: -1px; left: -1px;
+      border-top: 2px solid #22eec9;
+      border-left: 2px solid #22eec9;
+    }
+    .qr-frame::after {
+      bottom: -1px; right: -1px;
+      border-bottom: 2px solid #22eec9;
+      border-right: 2px solid #22eec9;
+    }
+
+    .qr-frame img { display: block; border-radius: 2px; }
+
+    .qr-cta {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.7rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: rgba(34,238,201,0.75);
+    }
+
+    .qr-url {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.62rem;
+      letter-spacing: 0.05em;
+      color: rgba(232,232,232,0.55);
+    }
+
+    .extras {
+      width: 100%;
+      margin-bottom: 1.2rem;
+    }
+    .extras__label {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+      color: rgba(34,238,201,0.5);
+      margin-bottom: 0.65rem;
+      display: block;
+      text-align: center;
+    }
+    .extras__list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+    .extras__item {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.68rem;
+      letter-spacing: 0.04em;
+      color: rgba(232,232,232,0.72);
+      padding: 0.45rem 0.75rem;
+      border: 1px solid rgba(34,238,201,0.1);
+      border-radius: 3px;
+      background: rgba(34,238,201,0.025);
+    }
+    .extras__item span {
+      color: rgba(34,238,201,0.6);
+      flex-shrink: 0;
+    }
+
+    .sheet-divider {
+      width: 100%;
+      height: 1px;
+      background: linear-gradient(90deg,
+        transparent, rgba(34,238,201,0.12) 50%, transparent);
+      margin: 1rem 0 0.9rem;
+    }
+
+    .sheet-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+    }
+    .sheet-footer span {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.62rem;
+      letter-spacing: 0.15em;
+      color: rgba(34,238,201,0.5);
+    }
+
+    /* ── Print: landscape A4, 2-up ──────────────────── */
+    @page { size: A4 landscape; margin: 0; }
+
+    @media print {
+      * { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+      body { background: #050507 !important; display: block; padding: 0; margin: 0; }
+      .print-btn { display: none; }
+
+      .double-page {
+        width: 297mm;
+        height: 210mm;
+        display: flex;
+        flex-direction: row;
+        gap: 0;
+        background: #050507 !important;
+      }
+
+      .cut-line {
+        width: 1px;
+        height: 210mm;
+        flex-shrink: 0;
+        background: repeating-linear-gradient(
+          to bottom,
+          rgba(34,238,201,0.45) 0px, rgba(34,238,201,0.45) 4px,
+          transparent 4px, transparent 9px
+        ) !important;
+      }
+
+      .slot {
+        width: 148mm;
+        height: 210mm;
+        overflow: hidden;
+        position: relative;
+        flex-shrink: 0;
+      }
+
+      .sheet {
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 210mm !important;
+        height: 297mm !important;
+        min-height: unset !important;
+        transform: scale(0.7035) !important;
+        transform-origin: top left !important;
+        border: none !important;
+        box-shadow: none !important;
+        background: #050507 !important;
+        padding: 10mm 12mm 8mm !important;
+        overflow: hidden !important;
+      }
+
+      /* A4 single-page sizes (same as folleto.html — scale handles the rest) */
+      .logo { width: 54px !important; height: 54px !important; margin-top: 0 !important; margin-bottom: 0.5rem !important; }
+      .band-eyebrow { font-size: 0.5rem !important; margin-bottom: 0.25rem !important; }
+      .band-name { font-size: 1.65rem !important; margin-bottom: 0.75rem !important; }
+      .divider { margin-bottom: 0.85rem !important; }
+      .album-label { font-size: 0.5rem !important; margin-bottom: 0.3rem !important; }
+      .album-title { font-size: 1.55rem !important; margin-bottom: 0.2rem !important; }
+      .album-meta { font-size: 0.55rem !important; margin-bottom: 0.9rem !important; }
+      .event-pill { font-size: 0.5rem !important; padding: 0.22rem 0.7rem !important; margin-bottom: 0.4rem !important; }
+      .event-heading { font-size: 0.9rem !important; margin-bottom: 0.25rem !important; }
+      .event-desc { font-size: 0.75rem !important; line-height: 1.5 !important; margin-bottom: 0.9rem !important; }
+      .qr-wrap { gap: 0.4rem !important; margin-bottom: 0.75rem !important; }
+      .qr-frame { padding: 8px !important; }
+      .qr-frame img { width: 150px !important; height: 150px !important; }
+      .qr-cta { font-size: 0.58rem !important; }
+      .qr-url { font-size: 0.52rem !important; }
+      .extras { margin-bottom: 0.5rem !important; }
+      .extras__label { font-size: 0.5rem !important; margin-bottom: 0.35rem !important; }
+      .extras__list { gap: 0.22rem !important; }
+      .extras__item { font-size: 0.58rem !important; padding: 0.3rem 0.6rem !important; }
+      .sheet-divider { margin: 0.5rem 0 0.4rem !important; }
+      .sheet-footer span { font-size: 0.55rem !important; }
+    }
+
+    /* Screen: responsive */
+    @media (max-width: 1280px) {
+      .double-page { flex-direction: column; }
+      .cut-line { width: 100%; height: 1px;
+        background: repeating-linear-gradient(
+          to right,
+          rgba(34,238,201,0.5) 0px, rgba(34,238,201,0.5) 6px,
+          transparent 6px, transparent 12px
+        ) !important; }
+    }
+    @media (max-width: 640px) {
+      .sheet { width: 100%; padding: 2.5rem 1.75rem 2rem; }
+      .band-name { font-size: 1.7rem; }
+      .album-title { font-size: 1.55rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <button class="print-btn" onclick="window.print()">Imprimir / Guardar como PDF</button>
+
+  <div class="double-page">
+
+    <div class="slot">
+      <div class="sheet">
+    <div class="glow"></div>
+    <div class="corner corner--tl"></div>
+    <div class="corner corner--tr"></div>
+    <div class="corner corner--bl"></div>
+    <div class="corner corner--br"></div>
+
+    <div class="inner">
+
+      <!-- Logo + banda -->
+      <img src="images/ojo-goth-blanco.png" alt="Hacia el Ocaso" class="logo">
+      <span class="band-eyebrow">Buenos Aires, Argentina</span>
+      <h1 class="band-name">Hacia el Ocaso</h1>
+
+      <!-- Divider -->
+      <div class="divider">
+        <div class="divider__line"></div>
+        <div class="divider__dot"></div>
+        <div class="divider__line"></div>
+      </div>
+
+      <!-- Álbum -->
+      <span class="album-label">// álbum</span>
+      <h2 class="album-title">Mitos de un <em>Futuro Cercano</em></h2>
+      <span class="album-meta">LP.03 · 2026</span>
+
+      <!-- Evento -->
+      <span class="event-pill">// cancionero en vivo</span>
+      <h3 class="event-heading">Seguí el show en tiempo real</h3>
+      <p class="event-desc">
+        Letra e información de cada tema a medida que suenan.<br>
+        Abrí desde tu celular antes de que empiece el show.
+      </p>
+
+      <!-- QR Code -->
+      <div class="qr-wrap">
+        <div class="qr-frame">
+          <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOYAAADmCAIAAABOCG7sAABJiElEQVR4nO19d7wkVbF/1Tkd5+bdvZtYFoRFwAVhlYwiWQSVKCiiqICAiAhKMIAC6kOCT1RMPIKgCD4UAUFB4kPJYYEFlgzL5rt7852ZDufU74+5t9P07e7pnQWHX38//LF36D5dfbq6T1Wdqm+hqupQoEDrgL3TAhQo0BgKlS3QYihUtkCLoVDZAi2GQmULtBgKlS3QYihUtkCLoVDZAi2GQmULtBgKlS3QYlCyHESOAyDXtyjJwFwby+S6QKJJInBU06aLiFw78hsqGiCGjnJsAMohQZZJiBscUdUynGjlEKmpYKiqqQdhao4BCbftwL313bcDy2mSZA2CMTk8OnzhFeSKyLNPBgnX2Gnb0hH7NUFyXS3ffE/1vkeRT6q1JCSf1t11+peAAhqDOHTRlWLNIHLmSdX++YO0bbcAuxGpGMqxyvCPryDbSZgEEm7boR/Vd13gD66p1iPPjN1we4LkQIQK7zzjGNbZDvId+jbpqnXf42M335UkJwBk+spKYXxku46vfYHsSnOEaxScixV9wxdfBdDg91IKbat5nc2QHDVTvLWyes9DkDChUrLO9o5Tjoqo7Mhv/iRW98OEyoIUpQM+UjpsP7KrDUjAmewbGL7karAcSHhtpTD23LHjhCO9W0bNGL36z2N/vDVJcgBgrP24w/isXhDNWpQaA2rmCMHYTXekyJnVMLAdsis09o6pLJUbeboBkCuaJTk5boaDiMYqEZUN/Vk7yrKpWqFKYyqbcRLIdsiqUHnilonIitoq8SeWqzRWeadUFgAo27JTuF8FWgyFyhZoMWQyDGLAOerpzl1OCJlxLUsFKhw1M7Q0S6JqHteYHJcAYHK3mgCokmlk1DU0zCSTtB6coaFTpUrCTjDpCQAYQ930ggaom6jlfFKoa74J3myQ5eQzQnKpLOdiyXLrkWeArYf7kZLPmKbvtl0TjCrGnFfeGrvuZv8FkMR6Oo29dmrYL3aFtmCLtkP2QT7p4ychlBlTs0hV/b/HybLJbuS1RCTbKR26LySHTVDK/sHR398EE5Y36pr10NN5nhTn1XseEavWrKenrO/4fj53do6nnEdlUVeth57u+/LZDX0mMoIAzF0/OGPvnamyriqLXK3c+0jlngeDg+tbvnfWfruS1ZjKUtVu/8wB7Z8/MOU4SalOFXJ1+OfXws8bjsuyjo45S+7GdhPkpOeiVlr7xTMGvvez8KPJFJetG0oduuDyyr+fWE9Pufe357dtthGV3xaVBQBQOOYN76fAsdBo2rCoKKF7dBw0cw2OQLbTWCQ1YbDGFQiERNOgchUQElQWAICxZj0aNPT195RB4flOLdyvAi2GQmULtBjyGgb1ICI3h/VJyHg+t5RcN22jnpAx4OkLUH3yALkiugXAGeZwRBBjvCVXUN3+Qhpkpr2M+FMlCQHBCAXWTKbGISTJ8FDZgApvaLM9AU1SWSLUVGXeRo1meyBjYu2gXDvY8P0Qqe+Zg7qW8OyRMTk4IlavTRmcyHn5TRAy8AMpc2agafhay1Cu7hcDw9ionIjRrAAiPmcGay81prVCsp7OPE+diHV18JnTaCJIgohk2e6SFTnmnPX28Knd1HAeAooly5OzI7KjOSpLrlDmzZ31+J8ajVlgmzl0/q8Gz/1FozY+uWLadRdp22yesMuHJXPk1zf0n3xe0uAMacxatc9xcu2AF80h6c647TfGHjt6EVw0jeGf/WH459cga3zGOMeAq0Gu3fPjb5QO27exDVsAAAIhU3yv+nNc29x/t6lX/9DbtUZNtZ9+ccVOn0lPTKsbquOEw7vOPrHhDXDOV2z3KWfx641eMRbNMwwAQIiGw2xCNPoMfEiZckUhssZfOYOgfSLdmO8BQwDIYmakI1Xy5oIodDnB8qdrSXpbJY9D4X4VaDEUKlugxdBUw+A/AcEF3fu37+hQvH9INP5fZChvhJihMgiQcEokkjDZMaloOPLQ8nh3qSxRyEqrmVzBOJeUwOP0gHPgQVuW1dl/dUNNhnozMXJK/eAQFwsjAJnBZFwfCQD/2Xj3qCyWjIFvXDR2052ojG+HknDaPr7HnFfu8BOsiEBVyQ4EOCWhoc2850qQ5EUbUVf7v3bBmi+f4yXBkHA6j/90aKh6ARTuvLli9f4nRD6f02+9TN1olhe0RkMf+M6l/Wdd7A/u2h3HfKrrO1/2krhR16yHFvZ9/kzvXmJBrjv9xv/W3v/e0B292/HuUVlAlP1DYvlqxPGbkuSS7SgbzZbBoAxB1OFF5HNmBH9gpi6HRtxlq1hgKGAsOlTk+qoi41SHz+rlc2d5GwGsZFK5EhycyJWDwxGThiw7eC+xIHKbFexsIbyLVBYmVsmJICg6LiCSKyB1Wy58ALmillwSGqr2e8JQiPHRHyEgcGKt6DI4ODhuzPpeU8Tk3BFH/v+mr1BEDAq0HAqVLdBieFcZBmQ7wVoXyly0iaYRShrRjfqVGlU1XJODIESWgh80dSyZ4DgTg5vgiqicTp2cUibX7dRORE3FkukFJVAzIycSAAgZlBw1rYkZyW8/3j0qS1W782tHlQ7bB3EiVYCkMmcmVRO1CpEse+3x35fDY+NbsgDImPP8q6j4NTOoqKO/+2v1gcfJs1ZdR99pQddZx6ZoLeLa489lJZNoIvhF0txrl/ZjDwVnwrolqWy8QVBOsh31fZtOv+G/vXuJh8JGLvvj4Pcv818wksauH5zx18vAcwQ17jz/2qqPfQkmhkJkcmQM82ZYv+N496gsCKEt2ELbbn4gmwzBdVNy9hBAyMod/5bDw6GfuRr60CKzn3/Vfv4l7wcCAEXNknJQve+RYIIbAbQffUjpoH2o6gUf6uSUkk3pLn1yz+TMONS1we9dZj272FshCMA8YI/SgftQtTx+jGGOrP5T+R8PrHtpzX8I3kUqO24G5Kl1QUPHUTU5bRfVSE2OlbFyNaocjgVCULWaUo4rZXqql5SoqhiksnIskJKswOCIIOX6qod5J1C4XwVaDIXKFmgxNM8wYIhtZsMp3lp+YohM4ysKJFOEMASKq3WpQ4SxlACycl2FvX6Cuu03AtQUSJ0HonpaLqpYBDIUH2AM9ZK/+awZqDfNbEVNRc1s+DTOPdd23dEklWVMrh0aOu9XDScWaYp132PA1o/3qirWky9U7nggif8RgWyXKtUUrZXC3Gsnfadt/WiUFOoWm0KGeqyOEz7DezrJK9SRQtn8PeAGTtQU6+GnK/c+kiSnJCwZHccdBir3XTIh24891Fyx2vcUOcoVfYPn/hTExEGqYj/1QnNmmPHqfY8SEDSa0oAo1w41K4OnOSqLnMk1g4Pn/SLX2ZmIcHMAVdV6fNHgj36T+oKjoiV/Bki45kc/1Hn6l8ku+7+6GeKyRJ2nHa3OmxsMCFDVDv6Julr911OpcrL2jvYvHISa4n0XyBUdXzkiqAo16o3hq/+yPuIDyJXK3Q9X7n4w/dCYczVsEldSUw0D9h/nk6KiNMtZJtshu5yD97NGgpkUayNANU1OIbFkxJxaH3ZoHvVGPdbTx6UhFO5XgRZDobIFWgx5DQORvgOeD9kTA+qBqgKK752gbgDDOjljDLv6lhjR3a9YcIaa6l9OU1BTY9p7aCqaur9PVqP3Emk1rlKSCM0DWTYaGpq671ohkGWnlygLQTJilmRr+BHO2WgiapkP+c7NSRnCZ04zP7J9cBe+WSDX0RfMz1O1zJm96BWxss/fTNcUGh4199zJ36lnTA6P2k88H6jlAuDM2G2HoFsDjNlPvSAHhyFhi58xuarffu5l/3IcxcCIuecuIS4VAuvx59xXl5CnZyS1+Zux6VOS7pEk6+nUFmzpHyMBS3r13kdBVfyXi6T2wfmssy1Ja0ny2dPV923qR9aQydGy/fiitCCJ1D84Hxisp6fMZ07Lp7V5VJYsW99tuxn77JyrEVAaMCclMhr68E9+N/q/twc33Du/cMjMu68NbLir1qPPrtjxM74bQYS62nv9Ray3B1zpDbVy9y9U7384wYmp8bauPvqM4OXUObM3ePUfIQViuGzT/Zyly4OHTf/dhaXDP5qwH0uuo87fbMad/+OzNytMrh5YuvE+wSgvAcy693f6DlvT5C13yHWMPXea9rsLvJQG1FV74YvLP3BYMhEGWXb3D08BztbTUybLyUd8ndswEDmYQdc3UFNDzrJjAWNkBxppSBGb2EUVi8rVwEtPmT7zPOybOy7qGpWrkfYeqGsY7BnmWJk4yKQM5SFwRlULTR0k+fE4x8kU7BSC7Ko/CUJk5DFvFpd6c1G4XwVaDIXKFmgxZDMMavX7TaGjygGemc2ztpoHd/DXa6/AmgHgX05k9Sci8+n9I1XyGvsBeYaxzLRDjhi9XOx88kzEpusLnGfc0c2isiiHR8WKvtz94tYVnMnV/emH1Vgpe6d44RtybNbVsb74VIjQ0MKXE6y3J8OZKAeHxYo+n1axpIOUfPpUzzcnx2ZTuqKSM+QzplHZ8pZGclwMBhAmuRxVrODjQ1WRawbrjxuf5Lyxp3UElgw5PJqFuTZdZVHVhi68cviSq99ZLh1y4tgIgweUq93nf7Xr3K8EbpuQZW1K2LA8VcvYY8fZi24JXg4gppdiBKhq/d+4EE+/OJAqYHeceOQGr94ZEJUAWchTFJJ1dcx86LqIFKgoyWFsVLXy3+6r/OOBUNUaUShcgEiOu2rvY5IlX79AJCGzRIuzGQauS+84HUmWgn1FiTlo/b1pDJHXTXGWy9VaiHlnuA4AoK5FSRLqhopJ1MxyOSnJqgvv1M1n7h2cZiLDU86msq3C7/D2rwP5rhg7n/U8ds263GRXzHHMfwCKiEGBFkOhsgVaDNkMAyEjHR2QYTQgkrMjTVbU7y6iwlFVGlorx/NmsmCcHWPchCeIizoxxOgkALlRq59cl0AEK38xS2EJYhaqgZjOOSIkefbB83e8yYAmdqRBNS0XmFy767QvtR31cW/zEA2tcvv/DZx9qU+L6QrlPRv0XnfReomDMibXDvYd9vVQ0IBI2WRDNLTGzDtEqlju60v9cSRhmzH7qT+zad1+fIeh+8ZyGiv7aTEk+YxpbFqPd4Oo69W7Huw/6xI/MuUKZcOZvTdcEhHJffWtID8hGnr/Ny+q3vuQP3uO1XnK0T0XfsPvwKFr1mPPrj3x3OSUFHLdaVf/SJu/qU/WyZhYvloODCUk9KCqOC+90XfUWb7WEqGq9N74Uza1ez09wb4jT3dfX9YUvo8MX1kiPnu6tu0W/oSWDHvRy6EHQ4S6pm2z+Xpp/MC5WNEXfUcRnZfeSGammASY3hdFkrrJhpEPIYnwTgFDOTRqv/AqThhXBDK2ZkHd4j1B4bFksq72lDcNkcYqwcFjQSCjVWtS8jkzlLmzksauhR3qKMvVLTfhs3rX0xNEvcGPy+TIaBgIsh0/CKLwGM5KIrJztitPAY/v0taUjjyToX59j8F4yYpHe+HGihQVXlEyfckQQ4PHwokjl3UFQcpTiJ1Pctz19wSbGMwp3K8CLYZCZQu0GN5uTi40tIZzLziPLy7NW+CRpfoUDT2FokszM1JaYMkI2bJaierJOm0nfXedKFKlQwCoa1gqgRL43XIiVg0qHAKioqaiGTOf6SBAXYWI8SPiU5DTB6srXspID/C2qixq6vBPr7WfeTGJY6IeDKlikRDBB09CdJ/zVWXDmdSI7YUKd15fNvRfl0eDU1E5laEfX+G8+FqSnAp331yefiOIA2f8RKxe618Rydh529JBe0KAjEPdcl7Kg5eEHaUp550JuhrsrDt61V9Hfv4HL8+BhNt21CfN3Xcg2564F7X6rydHr77JF5UzOTCcPAPxt2Jo5b/8s3zb/d5QJFzt/Zt3fu2oRjd7Sbgdxx2u77yNdyJqWvWfD47ecHvqlL69X1mFV+56qHLPQzkCdNFPo6TSQXtp227hPZtMg+ia9eizQz/8TcqXnvPK7Q9UH1uYHjvNkMZRvvFOZ/mKUCHN9f/ddsQBZIXJOpOfOhHqWtvnPoFthleog7q2/GcHW4tCZJ3a9u83994ZvFlRuPvKktHrb4vcSx6iA4VbT74QHIoAzNX9nacdDY3mJ0hh7L5925Gf9CYB9RINj47+8Vb4z1LZ2kLWLC6MqkXlSmPvd+YaEjSaJieaerSQxhVUrTTcdrnGyYXg15YJgVqUrDMm9qnwpt1LhCLEsXITfpFlk1Xxk9dqLdUzoHC/CrQYCpUt0GLIaxjU+7yWjW1mcoct1A1y3To2Bx6NwAtJMmWNGHeW20xQJs6t8VCk5jlIGWS3BAAoA5o6tpl+UbiuZ61cDVBaEEDGtR51DQ0zYc8ddR1VJTJRsbnqVI0l6/T5NFE3MJmu1DvSNJKfYI2mM/rcXRd1089zRwBJ9fNAFYtA+O0hoLYl5p+YnbY1l8q6Qpk3t+Pog3zPkQANbeSXf0zeQEWFafM3U+bORK96SVHsp16wn3zOZ5OUgs+ZYe73YUjcfyKCyl0PWQ8+RZ5hJ4Xx4Q8q7904SWuFZNN6Oo4+OOQvMzZ2/d9DNDOqIlb2pRBcSqG8ZwNjr509OUlInqWQhvHKnf8Wff0JaSjIUQ6PdRxzqD9RkrC9FBSydjulQ/fRtp/v3Q4hyL7+kV9eS97rpynWgwvTyTqlHLvmZuxqT2DxQJUBZx3HHIYeiwgS6+gY+eXvvcuBlKy9VDpk70hX1LZPf0ysXOORHxKC+8ay4Imoq9V/P5WFVDRDWoxjTbnwjI5TjgptoCscdd2Lq6GmOoteXrb1J1OGAph502XmQfuQPVGHpJWGfvCLgbN/6ln05Fjmvh+accdVZCdxDKKmLtv8APul14Le69RfnNNx7KEplTOMoRm4ZYY0Wl06d085MhIan6W0TiDHKh360ek3Xhai76xnLUZcsd3hzqtvBVeSuJBkeHAAY8cFsx6+wZuo2q9Ujs4JmnqzyDpT49wE0HP2Sd3nnerdMmpG5a//XHnwScHL8WnTNlh8K3Ae3KRF0wjmbKBW6jv0pNG/3BGWc73GZV1BbuBR2Q5VbWRKSvDIschxqVoOUkzG+IlCUrWcssjaDupaurNcDxlOXmFI5SqaBo5Vs9bxenAFWeV6NUpFugI5FmpqZKJi0USyzvRTHAsAQoylUpLjhi7niklIReueJs8ZxyjcrwIthkJlC7QYshkGCkdNS/CHUFVj3T1ynPFS6dqfEJfbP55F7/jHCIG6BtLzonA8szENqHDUtUD6HJKo6+2NiJrqm5IMPTc2Ba4gEsF7yZSgmBFCknRDg2erEUBVAcYCToUWY95IScIffNKhFDUDi0AdxvuPek9Hru9K3QwqiyiWrLAeezbBuERFcd9YVh+10bbeHDWfG4Jcm3V1hHxSKfmsXv39m/sp+tLhM3utR57275wAVSWSKB0rp/v6MuvRZ/39LSI+tZtvOMt/TxCpXLWfXuwPhQhVG4RIeVpEfMOZfPoUT3hybXXTuc3J4SfiM6fy2dNDg2/+nnTiWETnhddkueKXPJiG7BuIeOtsarcyd1byaETkLn4tlSwiCkmsqyP4+EAINmNaAyM0jvSIAUD0AxMHAsCQu0cEnG+w6K987qzA5xnJcaOPmXNUuP+dMIzy7Q+s+sTxgYR8yadNnf3cLaj5GSGoKit2+az97EvBi5IrIPQhlJ2fP3jK5ecGClRU67FFK3b/fCTbP9VRJcfqueCbXWceS2XP6UQQMv1DGxcxqB+887QvTrnkzNDgMj6xPTS2rq7Y6bPWsy8EboeQKcEPLTlW++cOnnbNfwUGjxGSLGf5Vp8UK9YkONDkWN1nn9T13ePD/itDVQkEQDItidhmrjnqrLH/vT2H+5XZMIA8VTtkO+nhfSFC2VjIQIhQQr4QWVtvKhyCcjpWTHEiIubrgeMKsu0EJtd1gpD5BkdVSb8dmTZ4bX8/X92AzEMGvC4o3K8CLYZCZQu0GLIZBkTRVQMhK2cOw5SafZqEt8ffiZ2E+YeoVmSaOHjs/007CyBG5vp7iZWcRTeeYuTM2B0z9TAWN3g9cpcK1j/3jENlkTwvq0EmlUVNBSVsYguRJZZBlSqNVRNtWQJFibomjKFp+FtEQsQWfqCho2km1dk6LMYIZphyFgAAkmVH3ESyHRqr0FiAnJDz6PhENBbejkJEQ0PTRNWzqpFsO1NHmoqdEplyXdTU9EnIm9KKeq3qaeK5O9l8gPpJiEVeopZMOQY9536t/fjDgzwG5RvvXHvy+anuHutqT06JIsfq/Nrnu751XCDVF8hxaSTs3jJkXR2Rc+XwWGoF83i2V/DbIIQcHks5y9T7Dj21+tATwRtE00DDf/bkWObHPjLtih94sT9UFef1Zav2+lIkxjT9pp8pc2d57j+WzDXHfLdy+33BtIo66g29+u8n+o44NXmGyXF7r7tQ23oeWUmxBdRVbCslfSARyXZWLDhUrPQjBuRYvb+/2Nhjh2BSPJo6mkbSUAoXy1at3P1LIEXyOkxjDabne1fIchCWTDatmyaySbBkYEcpy4lyYDjZDyXpUDlMHkGAqorTusPHxexBsO6OLCV+0UVT4SwyeB3Q1KNFeQBUrtCo/yKRdGikHH0qUso1gxGVxc52Nq07qLLpARAEcFw5MIwskS1GOthusmk9KaGG+knIhnHJg3UckxlpQUiSawdBpKgssEwN2uuR2ZYV0l/LhMw6BalZpzLOJibyu7ElnZsrjE8ZiKpFHFUEIvAgL8skFhtnEZUFKaOzl5EtvjZaAiQDGX40zUVE8uzgDIDWE/tnETEo0GIoVLZAi2H99rBFRUtdHVBRUDNyrPJUtfOEbxhGPWgCstKHIseFANfVRPqOATSRV6+qsT1sc8aYZMwMN61lPWLQlQREYIwsm6QLMsBPqnA0jcaiUQpHXSPLAshhq9SVVMVeofFxgaq2sfv2M2/7TZI6IoKQa449R67uTzDIUFFHr7ut+uBTjRpM5Iqpvzpb3XTDhlhRUVXsF1/vP/lH6FWMEaGhTb3ifNbVkfDakOt0HPepts/s77eR0VR70SsrPvwZxAkXW0g+tWvG7ZdHKg74zGmNMu+S7ahbvzc0w4zR0OiaY75LFTtrWHcSoKo4r7619sTzAxnxBJxP+fX3WXvJfwM1dfR3Nw/912+QNaIkUrKujhm3/QqQQSNbwGjo5RvvHP7VH1Nb5ub6ykrJpk8xNpiRKAKCcNMpGpGJN5e7byxpVAQCoLFKwwY+QxopVx96MngaagY4qZlcUt10rrHHTlSZiEOZhugbqP7riVAP2w03MPbYIXLLWT7hUUjJujqMPXb0f+FM9g1k7IyVAkQaq1QfeiI0CVyddtUP+ezpXtwQTWPo/F9X//1ko+8Hnzmj9yPbAW+Qrdo0nYUvei9MAtbBMBCJVgEiiDqC6XgRcuXcNJom54GF02IkoaFlWfvIdcm2/IgPIggZ7WGrqVS1mkNMKWUousRZM7NPEENsIESoqWQ7VLUCDcUxD2eHK1BTqWoDz/b0PXCWMf+4cL8KtBgKlS3QYsiaY4Ba2nZXHOFCFkQ88UllyOUso6KArgXrTFDX6qg3aJx1Qnieh0G2E+WYcNyo/SDq+EfydnJEVQnPMMbQhxHRWIWE481WTGESARpaOCGk7lrjkyBCFUSum9OeCfOPAABVLGwzI0XhVKmGtp/q5ESt1DTqDeRK+ZZ73aWryJl8V1BK1jul82tHNRqrIuGae+5o7Lcr2JPbMYhyZGzkp9eQm7YHGDlPVasPP1255W6f0AEBuTLlh6eGHijR0EVXhiRnYO63a+nA3b1ADQnX+PB2wX1Rclx1/ryec08OMFdK3p2nZS5ypXr/4wOnX+DPsBTKezbsOO4wPx4iCUtm9w9PCRrxJASfPSMYjkBdLf/5TuuxZ5M5LFDhU35wanAGgDPWXsrx+NQtNmk/+qBQAxwpB876aeidIeo8+bN8+hQSPtHG2HW32c8s9uREVbWffD4Li2uGryzjlXsertzzYJLoAOpGczpP+Vz6aBFIoe+8TdfpX04i2uBcrOgb+dnvs3yMQ1AV+5kXh37++6BTr8/fYvaim/yEDIY0Wlk6d68g9QYBzLrrKmOvXUPMF7ZDduBD67rKZht1nXVc+HZyLTWMW48tsh57OiiAsf02HSce4asCEZp659c/H/nSU8UKxQc1pXLngyO/vzm55kl77yYbLP5bKD5IQJVq45ENoWyyYdcZx/kTpXDxxvKlm+4TObD9s5/gM6f5ompK+db7xm65a31Rb6QP5Lg5iaGh1lWiEtvLZRyc519wlQi5pIO6SuWK/72Mpd5wLLIdqpSjS3O9YZAgdkNyqkroWTgWGnWGEFE6zQcBamqKm+84qGs0VmlOoy8hQpybCqeqhboZSosRIhpLpvy0rYX7VaDFUKhsgRZDJsMg1aknALIcLBl+qnltKyFftJ8z1DXffFd4iPhtcqCmhggMdQMYq2+kgSXD904YxiZAoq6hGWjLgQC2m49rAw0dGIakykL+xRgaBgRJMInqGbjQ0IAxf3DNyNrxNBfqEy1iNjiIyKpGQhaoq1gyPCcbNaPhLi8TyKCyUmrbbK5uumFSIw1JrKu9/Kc7fPsda6Ug1Ya1ljOxqt96ZKG3dw+MycHh9Axdzq3HFrlLV/gnqlwODLUduJf/4IlYT9fY9X/383EZUNUJNuysXbF6/2Ni7aA3xURC23KestlGOTq5Vf7xgByroNehU9fE8r6UrVfG5JqBsf/9hx9IIQJdNffYERRfQYGx6l2PiKFhf3BDc19f1px93XpIqc2fp26+sa8Jrqt9YH5oTojQNEoH7QNS+qY/UfXfC+1Fr/gP0dDE0pX55ExXWRJOxxcP7jjlC4F2FFGgpjiLXln2/ihZJypxfDuJQFV1nn2573NnxrSjSNR+NLSRy64fvfH2YHyg8wuHTP/rrwM9JFTr4aeX7/zp6OCKFqKS5OrgeZcFDyCAnu+d3PXt4xr2txD7v/pDZ/nK0IY+U5AnebTIVeeF1/oO/3rwR9bescGLt6Hq17GgygfO+on1/Euh20ElNbMkH0g4bUfs13X2V31NwBr9Y+BDKySb0tV7/cWAEFwnl232Mef1JaFJyCtnNsPAdsiuJLmrjkJWBrLOjOB56Sb1sLPsWMBYSHLhku1kod6IXt2xcvcfRdPAbGl1IXCGPCCDkLEkmGjoOZlEcmE8vJMcuKiPbHCOupZnEuJQuF8FWgyFyhZoMeT9UDMMthtAVQHOSbohJwnBz6T2IAQFjiHv9Iklo8Y+SQCQGOgmEMAZqkrAsFOAKHgiAQBRdPDcDnWNL63RpQ0RhCAQENjtRoXXl+ZSOMkdGdZbWVjjfJCBWxa1biUNhDIIZCyHQEQqVJWJyojAfNbv6CKmk6fzuvuFGj9p5JZZFs8nl8oi0mjZDZBCosLFyj71PXMjPqC7bDW4Iug58pm9WPIdCBIOIDovv+mFb1BT5eCwuvEGyQ4KuUKuWuu8vMQLPKGpo6kHTyThoK6FB1fE0lV5Qm+Isn/QeXlJw/uxiHzWdJXAf66Ioq8/lJ9OxLo72JQu/4VHpKolVq4JiSql8/pSLOlBlWXTe9SN5zTUYJVcl284M7o3S+S+uTyYxYG6xro7Q/Pp2qynM3QiIpWr7uq1afXfLBqTIWIzprAguwJDOTQq+4fSK69ytPfAkjF23W1rvvRtnxTWddUtNpn16A2hBGEhli84TLy10vuwkWNN/9Ol5id393WozRw6/9eD518WGMo299pl+m2/TlYOVJUVOx9pP/ui53WSa0/99bntXzzY2zzEkjny6xv6T/mBz34KcTXo2ZEj14lo1hP/q86bG+Qx6Dv81PLNd0WpNy76pj/Dhl6995FV+3856gUSBOOd5Doz779G336rxikTw8xFNeqNbQ8VK/t86g3Xnv7XX5of3TW0ax2eATT1yq33rz78lNAMxyI87eRY0678UdtnP+4/rDZz5KfX9p9xYarbvW4enC8HAgBQmJdhsgccPMyP4+Kkx0w2SO26CSdONnhu5B4nVqocxyCEEx3ipj03ajxrjT6I8XNzzUyWW65D4X4VaDEUKlugxVCobIEWQ1Ob2wctIe/f+SyteqOq/oDsCDu5cQdAtPIk/rDGj0m49yzTknIMjYsRYQGrR+pk1vZXszys4FCBoEcDZ60bmqOyqHCxZMWKDxwWsqY5n3bVD9j0KX4uOhGfPpWqScXNqGjWo4uWb3VgGgECiuWrY+K+AVClWjp4L2O3D/qBG02xn32579Pf9E+UhCV9xt9+hT2dXtARDW3N579tPfZ0MI7R9Y0vtR/3KZ+a09Arf/9X/2k/ChwjlLmzpt/yi4jkfPb0YK0LVao9F36z+/snhYJcXe3BNHaybG3BlrOfuiklrUJV+r9+gfPyG34xj2t3n/PVtiMP8OU09bEb7xz87k+TnHoiUJVpf7yITenyI69EfMbUYP4Alozhn/xu5DfX+7csHH2HbTZYfHvyMwXGVh/8Nfe1pZnaX6ahSV9ZRLId55UggwYB53zODGXurGDgmty08nZEqlTDQ01yYH1APgIi1tnGezr9U3RVDAzXfyyVjWez3h6/XNHU0dAj0Q82pVvdbK4fhzINe+a0yDGocnXTDaPUG5FKQCI+cxqGs/RJyFCUnggNXZ03N+nuAFBX5eoB542lHhEEgZDDY5EPIY2UnTeXJ5JFEGoq33CmMqs3mJYVfViIsn8oOBSBUDffRN1so5SykRp3dFPCGs00DBBDSQ9EwDm4ghy3Yb7myFDrAkmh+k+GscJQTU5vNVB4zPxKSY7rF58obkwiIgE5GUpVhaDUKSFKL3RhCJwhMH+6nLqSFaixjUDSlBKhoow/rOTsyvEGucHLsdC0xCILK21mFO5XgRZDobIFWgzr0Nwe8lBJoq6Fal20uNYUQpKM7kDWD07hqxPUKnDMUPGJ467Hlqr11BtVG9vMlAIKBKq1IA3+piqgqcH+KSBktL43DlS1gkwiBACsNgkTI+kG6nXZGpJIhB2mbNQb5LjRW3bd6JzHVcZTxQqSfRDUkmj9E1HLwMcPADnJOi1H33VB77U/9ktWFCaWrh4485Lk0gjU1aEL/sd+8jmYcNiRc+fFN4IZMCQcbestur5zPPhUA0wODg+cdiG5IdaJnh+frmw027dNNW79a+Hqg07wlw7XNfbaueOEw1P82Vwg29F22Do0CQzlyFjfYaemkNK5bufXj9Z33sZ7l9DQyn+9Z+wPt3rTAq6rvm+z7u+dmPy+kSN6LjgtVEijcfuhZ1YfdIKvCpy7S1aEZ1goc2f3XPB1cD2Hj4CxZLpSAKCq3XbEftoHtgiUKjGxZFVozoVk03qmXHI6MOa/A1JO+elZcnQsKKf1f0+u/ssd3onIufPqW8m5UDXk+soKwefMbNt0w8DHUnGef23gjItTTuS8+u8nK/c8FH6m4WR1KfmMKW2f2o+qATaHFX0D37wodJIkc59dtG039zJC0DArN90zdvM9wUIa1tPVnEKJegjBZ/e2fWq/0CS89Oba489JPo8A2g7fHzgHLx+Rc+elN8Zuuy8oudE3CPykFBmkNPbeMVSuaJjV2x8Yu/nuJEoLKVlXW9unPkphhp50zkYhtPnztG23CFxOr9x019rTfxy8HJ/eCxd/M3zPZH5011DNpmGWr78j+LBqp64vSuSa9FQOMjopWVYxgGyEC0JSteovLpzXV5ZCbU0sV4O8LxP+rF9Ik3GtyQkhQ8EdVyHLTicud6z6rNA6ihArY7Ou6AJSPwmxkETlag7qDXLccG4ukStCl3NFDGlI7X2IyJm3XKpwvwq0GAqVLdBiyGsYKDy4cqGq5ObkigFnaJh+SJxzNHUqVyjQMYJgonOiVySjlSJNR2pEG7l7pUaAmoqamXRA7knAOE/cdtAohdxZonRuMoQIzWg9anwZ2Gamlt9Q1crQIy0aO4oVEk0jVHavmbkrmnKprKo4L7xa+fsDfv0GY7KvvzmpD4y7b64YuvDyCP9jx9c/H3EOyrfeV/nHA35giCPfaFbXqUf7ii2Fvv3WSTSgjUhVve8xAkoajTG5djDP4Larb79V18lHhUhFFXXov34VuBdCU28/+kBQOST4SLZr7rsL6+lIJesc+tHlyUKRcEsH76NsPDtp89IVyiYbhiSXxLo7opqAOHrFn8XaIfSMeE1xFr+WLORkyKOyqCrOwhcHvvfzGHaMdQZyxX15ycCZofgA7+ne4K17gvvUqKrLtjjAfum1oJc97fLzO479dID3E8F1qWqv+4cWuVK+/f7y7femH9n4JJDlGB/ZzthnFy+bDDWjeve/V+z9xaDgrL297cgDUEtqm0GWUzp039IR+0cT04ISapr95PPLPnhISkMTAG2rzdV5cxPa6ZDjKlu8p+fiM0OXq60GQSEZG7roSufNpXXUG3nUbx0MgybpaAyirBMCTYPGKhDcvlcd1LUQ64RjgZBklaMLU7MMg/VHb4F1nriQZDuhGRYSS0lmiT+UZUNyIxDHJctOJ8KIi2zEQAgaK6celZN/JA6F+1WgxVCobIEWQxMbgiKqmaLfUbiCKM11tR3UtWDjO1QVctzo9nqWFo2Sou09LIa6hobu58saev3OM7kupKcMxkwCOXaokhviCCwUHjTs0NBjNkEQ0NDQ0IM5DGTbkZSGGg1K6EQhorsGRNH2HoCoqM1xoBFRV0MGGefkOJErIlMbpRisYR26K+68rZ/ojkiVqv3UCw3fM0m+0Wxl49lJ2kaStZesB54Azn0HhTPtfZuyqV3I/Lp7PnNqSoMKSdhRMnb+QLAhKGiK9cgzQUIQ1DU5NAIYDDBJddO5fM6MJDkRqWrZT70Q+VnfYZtgwji5NpvWE5KTM7FkpfvmskD1hGY/tTgkAAI4ovp/T6ARaFhJpL1/c+wo+VrLmfPiG2LVmmDJA58+VXnvRsHaEGwzjZ0/GKoRILKffD5KkJEDiGTZ1kNPhxwyZNpW7+Uzev2IAWfO4tflmv7QPWZD/h625r67+CKpivP8a8u3PaTRDX1ynfYjD+j+4alUndyE51ws71u2yb7BZG0C2ODxP2sLtiTbdzXIdpMzYMhx1XlzZ95zpf8TQxqtLt1kXzk0FDwSuRqkkiTX6TjusM4zjkuQE1XFeWXJ8q0OilRiTbvmR0HqDQAg2wkVqBh6+cY7+7//s6TEAMbk8Ojqg0NZBwQw695r9B22CiRa6MOXXjty7V+DgZT2w/efdu0FXj0FOa6y0eyZ91wREB3JdpZv+Qmxom9dUzI4k2sGVu1/fKTt8gZP36zOn+e13EGj1PeZ08au/1sOD34dDIPgvn+EZLQRkOuSXY3NIhgH52TZaOhgM18bHJdshyrVhnMLZZgLmyFVLdS11HWKnDQ5XRH7wlDVpoqVsqGfJQKDWEch6tTXIKBal65QH+uIEIIjku00rXAAEXU90t5j/GF5k8BYo422PRTuV4EWQ6GyBVoMeQ0DxNCSxBkwBlL6fiJR/iB+7OBCgpABMzHbshIZCgAozmGvh5Qx+0c8kU3SkzOVVaAetcOS10qEmAz6GsFlwK0ZF1uE6nVTJEcEzkDK0BOMFb5+PiOoTUI9anLKoJx1t8zSyCsAID9Zp2UHuwagqtDwKJva7RvvRMB4yu3FDw7kODQS8HI4l4MjbGoXBXthOm56iASRqnaUBF3hrKMtVQrW1Q6BqBO5NhDJvoGExJTxSZjWHVXZ1CYWRGjqrKczNclVDo9EXiQ5NCLXDPruV7kKCmdTuoIMDKCqyZIDIjku6+4gx/WZD2tGcIQgsVxNSYxWuBwYjpF9cFiuGfTpH8tV1NSgnDBu9KdzoebKMTD18i33rj3he14MkhyhbjZ39nO3RL4TaGiNVoSjrlcfeKrviK/7AU4h+fQpMx+6DtVQLTzqWrLvhaYxet1tA9/8cUBOV992yxl3XZ7MbkmONfWKS4zdtvPcKWwzBr//y6Wb7JMQeyZHqO+ZPfvpm6KMloaW7HtRudr++QPbPrN/0rrEmVw7uGLnI2ms6n0IUFXXfPp0YMyLKJFj9/zotDkX/jPAWKqP/fH2ZMmBCFV1xn1X8yBPChDqGlm+gmLJGL74qqGfXJUSgK+tYxiKy64+8OTg94sce+rPvjvlsu9Q2aNtNUYuu37gOz9Zb2SdrqBKFezx2yPhjuezRargUzsfxaLWfWli8FrPbCwZUfqGLIM7blhOJ2v1hKFjm+l9yLHNBKKQVHUg4VLVxjYjup5mkVNVUEt8FpxhOSazkapWKCNF2MAYtpl++WDJAMaSJQci0MT4LQefYJ3kNcc/aSiAcdLPVDl5Tc6J169tfZYrjosF4L83AgERJOXU0Vh4g1Ng8EYDMbUZiciZBUSh2/H+kWDqeJOQizk5KaUQAHCSYWt0Wr4MAAANS04ADKO3HC9GeD6zI4uc2eatiBgUaDEUKlugxdBUTi5dAxHwMzISVHGOmgZelw5dA84JABzPQ5KxbhaqKjBMymWu0XzEyumBITiCbIek44VgJoghNKCJRBlNm2h3M6nfRiDJcVFvCl8a1ijAUo8jxwXwI1ME0QeButYUvsFxjJfNrCubyQRFiOaZzqjFPaw4NI+s862VK3f9rK8/RMBZ73UXshlTE8KNqGhj19xc/eeDnk1D0tG2mDf7oet9NSVAVcEwtRsqfM3R33JeWZKU2c5QrBkMhlFQUZyX31ix05G+CUUEutp73UXYUfLJOjV1+JLfDZx5EbKJ3iHSLR20z+xHbkjIYUDOxer+lR/63LpnlZNrawu2mvrL7yZvg5PrTrviPHXLTfzgkaGNXXPr8gUHI/NqnFD0D6W338giVcVqP/Yw8xO7r3vCFxra6G//PPzT34Xk7BvIImfzyDqrlvXEosDTIkCenhmEKFb0uctWBr4Tknd36TtuQ5VAPQxR9EOLaD//ir34VUyybQiRh95dRCpXrcefDcqJhqFtvRnr7fHfeNMQy1dbCxd7gxPItk99TN9hGyonpMWozstvWk8+1wSVBYmltnQvh0jdchN9h609zcZSafTXf7IWvhCYFgLkzfnQSslnT1fmzkpY2TICS6XhC6+KyBl9WJOguWSdgVekRtaZ5XXkPNj1DhyrlgeT2hgIVTVP+9aInJJQU8dTq7zVgDHgtTyVQJUOEdmJUkkix21O1mnmlrnkuKG5UmxADEneXAiR1DA+OxR7giKkYTkL96tAi6FQ2QIthuYZBjH8j4Cmjm2mt2eLmpkpg5gzNEohSy4L60QcMlW/lAlNA9tMv5BGM/LVeAARuVGHKZ2la9zxDzC+15NY1QYfq5BwvAPja3LyAktGzP5l+BCwbbLdHLZ6HfVG6e2l3qgDCclnTu361nHhvRMa+vGVEORrURRn0cvJDVeRK87i19cef7YX9gJJ2NXe9d0TMJYPPkkq1/jQB9o++/EUs1jKwe/9ItRrV+Huy0saagwLACQkm9o95dLvhNwvhKEf/lb0DeDk7wAJ19xn59Kh+/hySsFn9oaCXJKwzZzys2+RE0idllLZcFYCz0BWIJKQA2f+hJmGF9eLlbN0wB7mAR9uuP8oY4Pfv0ysXONPgqLYjz/X6AyPn5rjnBhIybo7Ok78tJ8EgwjCXbrxvmJ1X/BAZGrKh5ZxsXT1yG+vD/7Ge7q7vv1lSGpQESuV0LbcpOP4I8mqTHoMRxqtLJ27txwJ5R8hVxvmMpGSdbR1HH9E6EfEkZ/9Qaxam/TZlkLbZvOQnPWUyERo6O3HHBp5H6iSgYMom/Bj192SfAgB8FkzzAP3gEZVFnHs+r87b74Vod7I96FtqmEwVom0XUZDzyNZHPVGPqHIFWRXovmHQTCkchVNHcdyFnyGr0fRayFmZcdOlhPyW0cZkV6GlTmOETO4qRfUGwX+P0WhsgVaDE1tCJoBER4KAIihG69r7zGRLxvY9B9PMIgM7kCY0BOkRM1MWpoZAwlUsUg6CbU543v3oaEQRKa64khni9jBM9UJI6IZWbuRqlZ60CADuUkW0HhkIwzOUNdT9sO4QpadPAkAEK2DnwRvr8pKYe65M99wpu+lqdx55iX76cUBtkfBZ0839topUM5AqKlj194aipJwLgdGQjUqUhgf+oCy6dyAC0hsas/IlTekzJSQpUP3AcdJ2mhFoko1NJQUyoaz9Y9sl1p2UTpsX7F6LU7udJJw9e23ShkHkSy7fOOdFIxsSGl+9ENsWneSByaFMm+uvuu2aeqSDhKuts3mITk5F0tXVu9/NM1VRXOvnYzytknBPpU7z79mP7Eo1et9W1WWhNv59c+Zn9iT7InyCa009INfWE8u8klfhKu+b5NpV//Y59ysUW/M3ZPCn0HkalAPSLjtxxza/oXDvBNRKw3/4po1x3w3OYyIijZnyd1sek9S+o5W6j/lvIHAUARQ2m+36fvsQm6Kz9Rz4WnpW7hOGqkoQxotrz3hXBL+95gAZt37O33mVJpcchKuscu2U6+6kOx0fsJ02E5QTtQU55mX1nzlvNRA7QbP3qLO34wmTwFDrTRy6VVrH12I/1EqC7WStGolyPsQsyYKSdVyuL1HFUsmpCXZkGWHyDoJQMoUSgtJWDKoUqWxSlqBK+bswJHRzU997IjYZsJYoMbVcdJrIcfDJuVgeek6ISInz0AaIgRVbRorp9TAZWNRKdyvAi2GQmULtBiyGQa15uReHrGmxmf7ayoI5v0JgtWv46hw1NTAbn7cZhirDTVh5vP4EDQ5btBRjd9wl7Iuiz5vG/JwQv5EOEL1N5YBMrX3XgeQ7ZBwQPi5xVCbT79dnprFVMjdi52ESN9sIyI3MgmyiZ3CM8iNKJavthcu9gxQNDSxZEVIHRHJsu2nX/SVBhGEIMeJHOa8sYwvXOxTRZi6WLkmOtRI2V642I8f1dpmRO6ZSH3vxkHmSnId1tMZSnKQkk3p0rbc1OcwRKSK5b6+tOGUVin5rN7gUCRc1tNpP/WCLycRaqqy6YaNjZwRBMCZttVmVLE8W5aEEG+tsjWVHC85XZf9Q6lp9VS1nOdfzcOsOn0q652SFFYjQlVVt9wk9KOUQW7gdQSqWdgShaSwlMgw+nUkqs/PQEWJWuuuoAgzBavj3okdKvxVIMed/ej12jabB212EjI6m4wF81FQV6uPLVq561F+/E8Sthmzn/pzSqgIADjDwAcMTWPsT3esPvI0nMh8IBDqRnNmL/xLE78oEUQmAXV1xfafrj79PAayLzBMMUSO1f7ZA6deeb7nfqGm2k+/uHzXz2CDORsEouc7J3adc6I/lKlXbr1/9eGnBLsr8rkzN3jmJuChHCZyRfK0YJs5cunv+8+4sEnUG5wlJCJNXDPbWqPw9Fc721DkCnLclIVYhl82ho2y1/gQMhRLUtyJcMSEqA7ka7GSHdGbZQicI7CGV3nEPDv+jshkddTKVPPxOWRA4X4VaDEUKlugxZBtaVhvxlkDqPcVEMf/S0aM8IE1iwiIYobKfsv+kRNDpQqQnWQp+cTxzMa0JbghwtCEyzUX9feS7XLZVFZR0CMEfYdQb7OS41CtrmPyk5CxqJuIiKrmm3Feha1tg/CVDxUlfQYZoqr6nhxjoCr1DO6o1FUaOy5RmMm1TnJAVl/JXbc/RKAoqGlJNjQSZLOwoyxuiJmYU3LDdSlIZ6twiIbG4pHBy3Hs7m+d1H7cYes1vzgJnMnV/av2PibIioCq0nfYqagmdsd07PYjP9H949M8ycl21C02mb3or/5MMYCKvfqgk2lwxA8eOXbvdRfruyxISNSiqmXssePsRbd4Q6HC3bdWrtjmkJAqEky/87fqxhv47BimsfbL36v84/8SeT9tfacFvTdc7DN9cCb7h1btdQyVLc+aI9edeuUPtPnzUt5bQ095dkSoqTPuuoIFyDrR0NccdUb1gcdz9sZKBJaM/pN+UL7lbn9wRCpXs1wry/tHrLOdz+pt2iZ1o5gkB0quGUzOeSPpyqGR8HIPqCp8Zq//C0Maq8i+Abl2wHOHSbrppCFEaGi85A+FqiLHKmJlX9TAiMTOEOXgsOjr94lSYiWvD69KEqvWBPllSbqsq4PP6k0pxiLKUtXIpk/hM3uD/COoa+vOshEPRDk4Ep0ExCwRiWyGgZQgRGLt5XpGbMQ0Ne4m3ZgpIArdCCEICZwB4/6A0s1kV0WGYghSRglHYheBmlQJNXCxktdO4QFu9BpVfLMejQgPJVIiqeuK1EmY7Lzmi1KgwPpEobIFWgx5d2s4R11dL3ZOrR46S4GKk0Ih7xfSJDBTcwQZE81BXUPT8H9HANuty/bIBDR0LBlge+yZ5kSGTVD+ur0oxtAwAg41Q0OnikXCDlJvoKZiyfAz+RHIdvLt8KGpY8nweVKMbPwjdd2MY6n90dCBYSB9x4xrg7zeCmlQ16r3PDJ08RXBlpnNArmOvmB+9w9PSeOpFFN/frayyRyavD4ENcV+6oWVe30OkxqlIglJI2OhKh1FHTjzJ6yn0/NayHXav3ho2+H7ZWy1EBge1x5zNgYoLYhk6YA9Or7yGc/NR0Mr/+mOkav+7M0nKqrz3Mur9j3Wd5skYEnv/eNFoCr+g1fYyKW/H/j2Gi/5gVyn46TPlg7YPdiWI4uQ5Io1nz0zRI7LuL3wxeRHTJajbT9/xk2/8FvREqGhRUvhGVt7/PfdJStRmZCTZOlju7Ufe0hoEm66e+S3N6QqVa6vLGdi5ZrK/Y+tj0AzAYCMa3AVPY70XRZo226e4CyjWXJefatyz8Pp+f4RDiJk1uOLIpWP5h475yM6qP77iUiSZMdxR5gf+4jHRoqm6Tz9YoimBZkcGK7881/BcVhX17Rr/gvbTS9+jIY68K1LrWdfCJX3HLh3HjmJqg88FokPIE9LZZSSTesx9/uQfx4CEEVZeBGr/3rSeX1JUM72ow+KTIL7wmsJXDUechsGLL18Ih8cK2NnErJsqlhJ1ReMgaR8ckZXKMfKzSEVjTU6FghB1UADLc5iknsYQxbkH5Goa1S1gbMAn7NEVQkxljpW7r7JOeOvUib19fUG17VQIo5jgZBkpU1CHAr3q0CLoVDZAi2G9UnWmRWNM3HHggCNUIsI1EqoZ7Mx6oIPqb3uJxkohqwzekitmijARopaKZMthIhtJrYZnmGAmkaWTSA9v3uibUYptGnsimjFuZQZiDBiJCcnA1MnIpbCHGqcUzVEvUEAuROXm0fW2dvTcfzhDe+XaIp132OVex/Jx9sYBOpq+c//tJ/xWTxQVa0nn08ZmQg1tfOUz2Ep0BVR5WNX3+y8sbQhqUhI1t3Z/d2vpOyccbQWLrYWPu95d6iq1sMLU67FkMrVofN+BcG0CoTSwXuVDt3b9344iuWrBr51YaAFnNDev0XpkL09o5+E4DOmdn/7xPS0/egNusaHt0vZHGZMDo2MXPA/EU1oP+rjwWkh4apbb5avTq55ZJ1Tu7rOObHRnUPUzCG4rHL3g7DOKguaUr7l3tEb/x7Wl7RPOAEovPMbR7PenkARpV6951HntTcbk0pK1t3RdfYJyUehVlr18ePKt93bmJyIVKkO/eTKiOyzH75e33EbTx1RK6394hnDV/8l5Jsf9rHSp/cDz08VkvVO6f7eiVnvKwjbSaFEZkgjY0M//m3k5w2evUWdPy+oo2TZ8E6qLNSRdWZGRsKFDAPV3NI88QEqh6k3pMxJ2kqUnjxEgEoGuop6IEZPcRyyHCpXQl8+Fg7m1ChCIouflPmTnLIYBroJIkDdPE69UWlK+XHhfhVoMRQqW6DF8HZzcr3diOGpxPqYORo6moafKmoYmUpJOUMtmFGKQDKh/aIHsp267fV61MlZF44gAFRVNH1pUTMm2Eb8GEJG0wsNHTCpwSoAgpMz0aKJeFerLEm+0Sxtq8287mrImBwasR5+JpTvImTljn+zzjbfy9ZV2T8ISZkJ47vW9sLFXgIDkWQlU991QYpUQujbbQWuA5NvpiNjYu2Q/fizob17TTX23BE497VKSvvpF8XKPnAnLG9dwe7O0n4f9k90HW3BFuk+BlHlzgfBshPCHURSnbeRMm/uO5k5/e5WWXKd0r67TPnND8ga56lEXbMefXbFjp/23XNEsp01X/pW5FzkanJ+Bmqa/fAzq48+M+ibq7NnzX7u5uRIH1l211nHhjSvfnDdqN770Mo9v+B7UZKwo633hktCcVldW771wdaixUEZpv78nCn//R3vlgEQXDfl249Ijrv2i98WA4NJkgN0n3V897knvWP1KQDw7lZZAK+9x0TlkxDxqXH5kiUiPJWOW8eyPYlUqamVsi6zBGC8vQeCvxoIgZoazTGQkqxKjkI9NA0cUpJSFNahvUcTUbhfBVoMhcoWaDG889/5ZqKWEO0GNrKJUOE0kXiACgfGCCRGNrjrEwtFiF+SJk4PDYVIAOhfToCQUN8Csn4zncfQmAYxIac/OJAEIUDhoHDfMKhnSAAAxsYP8yDrKmwRQxkUiONlj1IkBAzqJwEgroQ4FpzHzEwQCs8UpXlXqSwRm9LFZ09HZTw2xISDmuq+udxL6JSqIvuHlA1m+hv6CEAkVvWHHioRmz4lyC/JhANShobSNSpXlA1mIFcnjhFs+hSxZGXIryLgM6aAwgOhMJRrBqhiJWit1FQ5NBIcHCSx7naxdBWauicVakq0eB1RDgyJN1dQ1WPfJyyZrKczkJmA5DhyWX/gRCTX5TN7QU3K6WbCAaLgJNR6PrKp3am5JWJFH2szEnqXomnIgeEshc3vHpWlcrX7vK92n3uS9wuWzJHLb1w676Oeh0SOoy9435zFf/N3OBnSWHX5Bz8l1wx6Hx5y7Wn/c56x+/aer4Zt5sBZ/x0eyip9cq85L9/htUREVXFeXbp8waGRovBZj16vbrphkHqj/xsXlW+5O8HnI8cyPrT9nJf+7isHZ3LN4PLtjwjyGAAASBmkikFFG/rBb4Z++NvgUO1HfnLqFef5DJuq4rzw2ooPfc73pYhQU2c99ic+c2pCAAvbzMHvXRaZBPNju03/86Up3h7nqw85JekATwylOdQbrYMId0PN+a0teTVIAUTAOfCJb2o9Ue74uThOGjDpUHJiqMAxHEN76zAJj0FtpU6IbsYMzoDzcZ4BCn1Wo+dGiDbkJAzaUnhs4EAEgo1fIgGxkyBSvq/jyBLKbSYnVwsh+HgCS+HETzj+u08jN4lWUeSw+qEmfg8x0kEmOjSMGypGhgx0d/HjZ3n2GLEoxi+RsMTHTkLGAsDmMdIVEYMCLYZCZQu0GJpqGOSo7QwyTDWKGhEnT7Tban/6hlRdM4UahAQpQp4+q7Nlcy9tNRvRi0zFDlXP9CbrbVk2TptFDUpSb3PHE35ls2UhbJhONp8Rmz5v3W89mqOyqHCxZMWK7Q5vlCgPGRNrB7P4ifVXXHPk6ahrfrMQ1+4+92ulg/f23HyqVksH7anvsi1OzB0RMUMPUVtKQkOb8c/LQ8FFXR08+xf9J/8AJmJMyJjo688hJyD2Hfw1VFVPTmTMXb46OBS5dvvnD+48/YvgxQc01Xn2peXzPw7BIFdn24w7L2+4tYuhVe96aPmWB3gVFohIlh0ir0UkV6z+2AnJmQ8g3LYj9p+96BaojG8mExFrM0N74ELw3imzHvpD6ETOVn/qNPe1pfWMuTnQpK8sItmOs/i1xs8kDFIONnJF5/Wl4QCokEMj4QAQse5OPrU7fMG6djeI6mYbhX4wDdk3YL/8ZqBnC+FkH6c0OK+8Ff6BkCshOYnYlC7tffNobCJ9xzDEyr6wAJJN6VY32yiYFpMF2GZaDy60X34j1H8G6zqREDkvv5k8FIFoQ9Tmb0ajfjtcIgrtlRCAytUt3hM6s9Y3rkk8is0zDPJ2P8t/wcikx/ZLkdH2T7GIFngozgS3SBPuKNMgUpLj+GJwB0S43Y2QqCjkuFBr9pIdtgNEWe4lXU5HQC3ZN7kehurms6ndaQr3q0CLoVDZAi2GvAufW0832RwQxLM9xhwZvjoBAK+xTqxr1Bo1I7XWhQDIFUGSC1QVNPRU6g0AQBZNS0VVQc0MCKCjUbedi4glM2LLUsVKJZWnuIdVv12cifwUALVS8mExqKPeAABEJR/NWXpDUHKsKRee0XHKUX4uOudiyXLrkWfyuSMpkJLPmKbvtl2w7bJYuWbFgkODKSAkRM95JytzZ/mlSKpiP/G8WLayGUuH0HdcwHp7krYZFS6WrbaffM6/nJTYZhq775AcNkFdG770WuvxZwMpL1J578batlv4fgxncnV/9f7H/BkmQl0zP7prMMOGhNt9zlfUTZMYS4Fz9/Wl9uOL/PowRXGXrBg45+fovTZEqCjdF5zKujuSXgBVcZ571X3tTaAGZ5jI+Mh22NHmDY66NnLZH6sPP+VPQmbk7JnN585uC3vZzUQWSmRJ5v67adv6PWxRL6257YHR//3Huu8MEkDHl48w9t6VrEmzPVA3x264rf9bl4QKaebMnnr5uSnNWvXS2J//CY8+7XvwjDmLX3NeeDlyYKhcEZEse+wvd0Tk7Dz5s8DmAkyuskIom8wJuvCoqfbCFwe++7NQC1uGpUP25rN6k9Ji9NLAmReO/inPDHefc6I6fx45/sMq33o/PPhEg210AfIbBkJQ+Z2sWQMAqlpUrvrlo4hNoxB1LHJcqlSSTBQCcEW0kEbXqFxN846xXi1QUdKfRRz1RqaFzhWhuJ4bX01EFYvK1aSFBREA8sywEGTZVA5Qb2DMJGRE4X4VaDEUKlugxZC1VWTQn327wXmU/BEAANDUsc2EiQA4amZuou2YwQ0dTTNhWw61Wie3yK+IbWaKLauZTdxwR1PHkpmx5eeEAGpsJTCWDGwzk2xZzcy9tzL+sLw893V4WBkkYLx6/+OEAMksjesPjMnh0agny9jYH/5WvfdR38vWVeeF1/zeLOt0RV6+8U776ReTqPk01V64OHQ5xuTw6Milv0+xZTXVffWtJsnJxv54u/WvpxrjalW4WL46agRLOXr5jayzPSlioKvWY4vySI44es0tfMZUP5FDV92X3sg3CelBLgAgxwn2unhHkCmOiEpTEi/iB48TKpWDaJLTcoYk65FNzjgZGo/LAkBMs6dsiCGdXn9x2QIF/qNQuF8FWgyFyhZoMRQqW6DFUKhsgRZDobIFWgyFyhZoMRQqW6DFUKhsgRZDobIFWgyFyhZoMfw/Dy4IB9jYiVYAAAAASUVORK5CYII=" alt="QR — Cancionero en vivo" width="230" height="230">
+        </div>
+        <span class="qr-cta">Escaneá para entrar</span>
+        <span class="qr-url">haciaelocaso.com/presentacion-album-mdufc</span>
+      </div>
+
+      <!-- Otras experiencias -->
+      <div class="extras">
+        <span class="extras__label">// más en haciaelocaso.com</span>
+        <div class="extras__list">
+          <div class="extras__item"><span>◈</span> Creá tu foto con la estética del álbum</div>
+        </div>
+      </div>
+
+      <div class="sheet-divider"></div>
+
+      <div class="sheet-footer">
+        <span>@heo.oficial</span>
+        <span>haciaelocaso.com</span>
+      </div>
+
+    </div>
+      </div>
+    </div>
+
+    <div class="cut-line"></div>
+
+    <div class="slot">
+      <div class="sheet">
+    <div class="glow"></div>
+    <div class="corner corner--tl"></div>
+    <div class="corner corner--tr"></div>
+    <div class="corner corner--bl"></div>
+    <div class="corner corner--br"></div>
+
+    <div class="inner">
+
+      <!-- Logo + banda -->
+      <img src="images/ojo-goth-blanco.png" alt="Hacia el Ocaso" class="logo">
+      <span class="band-eyebrow">Buenos Aires, Argentina</span>
+      <h1 class="band-name">Hacia el Ocaso</h1>
+
+      <!-- Divider -->
+      <div class="divider">
+        <div class="divider__line"></div>
+        <div class="divider__dot"></div>
+        <div class="divider__line"></div>
+      </div>
+
+      <!-- Álbum -->
+      <span class="album-label">// álbum</span>
+      <h2 class="album-title">Mitos de un <em>Futuro Cercano</em></h2>
+      <span class="album-meta">LP.03 · 2026</span>
+
+      <!-- Evento -->
+      <span class="event-pill">// cancionero en vivo</span>
+      <h3 class="event-heading">Seguí el show en tiempo real</h3>
+      <p class="event-desc">
+        Letra e información de cada tema a medida que suenan.<br>
+        Abrí desde tu celular antes de que empiece el show.
+      </p>
+
+      <!-- QR Code -->
+      <div class="qr-wrap">
+        <div class="qr-frame">
+          <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOYAAADmCAIAAABOCG7sAABJiElEQVR4nO19d7wkVbF/1Tkd5+bdvZtYFoRFwAVhlYwiWQSVKCiiqICAiAhKMIAC6kOCT1RMPIKgCD4UAUFB4kPJYYEFlgzL5rt7852ZDufU74+5t9P07e7pnQWHX38//LF36D5dfbq6T1Wdqm+hqupQoEDrgL3TAhQo0BgKlS3QYihUtkCLoVDZAi2GQmULtBgKlS3QYihUtkCLoVDZAi2GQmULtBgKlS3QYlCyHESOAyDXtyjJwFwby+S6QKJJInBU06aLiFw78hsqGiCGjnJsAMohQZZJiBscUdUynGjlEKmpYKiqqQdhao4BCbftwL313bcDy2mSZA2CMTk8OnzhFeSKyLNPBgnX2Gnb0hH7NUFyXS3ffE/1vkeRT6q1JCSf1t11+peAAhqDOHTRlWLNIHLmSdX++YO0bbcAuxGpGMqxyvCPryDbSZgEEm7boR/Vd13gD66p1iPPjN1we4LkQIQK7zzjGNbZDvId+jbpqnXf42M335UkJwBk+spKYXxku46vfYHsSnOEaxScixV9wxdfBdDg91IKbat5nc2QHDVTvLWyes9DkDChUrLO9o5Tjoqo7Mhv/iRW98OEyoIUpQM+UjpsP7KrDUjAmewbGL7karAcSHhtpTD23LHjhCO9W0bNGL36z2N/vDVJcgBgrP24w/isXhDNWpQaA2rmCMHYTXekyJnVMLAdsis09o6pLJUbeboBkCuaJTk5boaDiMYqEZUN/Vk7yrKpWqFKYyqbcRLIdsiqUHnilonIitoq8SeWqzRWeadUFgAo27JTuF8FWgyFyhZoMWQyDGLAOerpzl1OCJlxLUsFKhw1M7Q0S6JqHteYHJcAYHK3mgCokmlk1DU0zCSTtB6coaFTpUrCTjDpCQAYQ930ggaom6jlfFKoa74J3myQ5eQzQnKpLOdiyXLrkWeArYf7kZLPmKbvtl0TjCrGnFfeGrvuZv8FkMR6Oo29dmrYL3aFtmCLtkP2QT7p4ychlBlTs0hV/b/HybLJbuS1RCTbKR26LySHTVDK/sHR398EE5Y36pr10NN5nhTn1XseEavWrKenrO/4fj53do6nnEdlUVeth57u+/LZDX0mMoIAzF0/OGPvnamyriqLXK3c+0jlngeDg+tbvnfWfruS1ZjKUtVu/8wB7Z8/MOU4SalOFXJ1+OfXws8bjsuyjo45S+7GdhPkpOeiVlr7xTMGvvez8KPJFJetG0oduuDyyr+fWE9Pufe357dtthGV3xaVBQBQOOYN76fAsdBo2rCoKKF7dBw0cw2OQLbTWCQ1YbDGFQiERNOgchUQElQWAICxZj0aNPT195RB4flOLdyvAi2GQmULtBjyGgb1ICI3h/VJyHg+t5RcN22jnpAx4OkLUH3yALkiugXAGeZwRBBjvCVXUN3+Qhpkpr2M+FMlCQHBCAXWTKbGISTJ8FDZgApvaLM9AU1SWSLUVGXeRo1meyBjYu2gXDvY8P0Qqe+Zg7qW8OyRMTk4IlavTRmcyHn5TRAy8AMpc2agafhay1Cu7hcDw9ionIjRrAAiPmcGay81prVCsp7OPE+diHV18JnTaCJIgohk2e6SFTnmnPX28Knd1HAeAooly5OzI7KjOSpLrlDmzZ31+J8ajVlgmzl0/q8Gz/1FozY+uWLadRdp22yesMuHJXPk1zf0n3xe0uAMacxatc9xcu2AF80h6c647TfGHjt6EVw0jeGf/WH459cga3zGOMeAq0Gu3fPjb5QO27exDVsAAAIhU3yv+nNc29x/t6lX/9DbtUZNtZ9+ccVOn0lPTKsbquOEw7vOPrHhDXDOV2z3KWfx641eMRbNMwwAQIiGw2xCNPoMfEiZckUhssZfOYOgfSLdmO8BQwDIYmakI1Xy5oIodDnB8qdrSXpbJY9D4X4VaDEUKlugxdBUw+A/AcEF3fu37+hQvH9INP5fZChvhJihMgiQcEokkjDZMaloOPLQ8nh3qSxRyEqrmVzBOJeUwOP0gHPgQVuW1dl/dUNNhnozMXJK/eAQFwsjAJnBZFwfCQD/2Xj3qCyWjIFvXDR2052ojG+HknDaPr7HnFfu8BOsiEBVyQ4EOCWhoc2850qQ5EUbUVf7v3bBmi+f4yXBkHA6j/90aKh6ARTuvLli9f4nRD6f02+9TN1olhe0RkMf+M6l/Wdd7A/u2h3HfKrrO1/2krhR16yHFvZ9/kzvXmJBrjv9xv/W3v/e0B292/HuUVlAlP1DYvlqxPGbkuSS7SgbzZbBoAxB1OFF5HNmBH9gpi6HRtxlq1hgKGAsOlTk+qoi41SHz+rlc2d5GwGsZFK5EhycyJWDwxGThiw7eC+xIHKbFexsIbyLVBYmVsmJICg6LiCSKyB1Wy58ALmillwSGqr2e8JQiPHRHyEgcGKt6DI4ODhuzPpeU8Tk3BFH/v+mr1BEDAq0HAqVLdBieFcZBmQ7wVoXyly0iaYRShrRjfqVGlU1XJODIESWgh80dSyZ4DgTg5vgiqicTp2cUibX7dRORE3FkukFJVAzIycSAAgZlBw1rYkZyW8/3j0qS1W782tHlQ7bB3EiVYCkMmcmVRO1CpEse+3x35fDY+NbsgDImPP8q6j4NTOoqKO/+2v1gcfJs1ZdR99pQddZx6ZoLeLa489lJZNoIvhF0txrl/ZjDwVnwrolqWy8QVBOsh31fZtOv+G/vXuJh8JGLvvj4Pcv818wksauH5zx18vAcwQ17jz/2qqPfQkmhkJkcmQM82ZYv+N496gsCKEt2ELbbn4gmwzBdVNy9hBAyMod/5bDw6GfuRr60CKzn3/Vfv4l7wcCAEXNknJQve+RYIIbAbQffUjpoH2o6gUf6uSUkk3pLn1yz+TMONS1we9dZj272FshCMA8YI/SgftQtTx+jGGOrP5T+R8PrHtpzX8I3kUqO24G5Kl1QUPHUTU5bRfVSE2OlbFyNaocjgVCULWaUo4rZXqql5SoqhiksnIskJKswOCIIOX6qod5J1C4XwVaDIXKFmgxNM8wYIhtZsMp3lp+YohM4ysKJFOEMASKq3WpQ4SxlACycl2FvX6Cuu03AtQUSJ0HonpaLqpYBDIUH2AM9ZK/+awZqDfNbEVNRc1s+DTOPdd23dEklWVMrh0aOu9XDScWaYp132PA1o/3qirWky9U7nggif8RgWyXKtUUrZXC3Gsnfadt/WiUFOoWm0KGeqyOEz7DezrJK9SRQtn8PeAGTtQU6+GnK/c+kiSnJCwZHccdBir3XTIh24891Fyx2vcUOcoVfYPn/hTExEGqYj/1QnNmmPHqfY8SEDSa0oAo1w41K4OnOSqLnMk1g4Pn/SLX2ZmIcHMAVdV6fNHgj36T+oKjoiV/Bki45kc/1Hn6l8ku+7+6GeKyRJ2nHa3OmxsMCFDVDv6Julr911OpcrL2jvYvHISa4n0XyBUdXzkiqAo16o3hq/+yPuIDyJXK3Q9X7n4w/dCYczVsEldSUw0D9h/nk6KiNMtZJtshu5yD97NGgpkUayNANU1OIbFkxJxaH3ZoHvVGPdbTx6UhFO5XgRZDobIFWgx5DQORvgOeD9kTA+qBqgKK752gbgDDOjljDLv6lhjR3a9YcIaa6l9OU1BTY9p7aCqaur9PVqP3Emk1rlKSCM0DWTYaGpq671ohkGWnlygLQTJilmRr+BHO2WgiapkP+c7NSRnCZ04zP7J9cBe+WSDX0RfMz1O1zJm96BWxss/fTNcUGh4199zJ36lnTA6P2k88H6jlAuDM2G2HoFsDjNlPvSAHhyFhi58xuarffu5l/3IcxcCIuecuIS4VAuvx59xXl5CnZyS1+Zux6VOS7pEk6+nUFmzpHyMBS3r13kdBVfyXi6T2wfmssy1Ja0ny2dPV923qR9aQydGy/fiitCCJ1D84Hxisp6fMZ07Lp7V5VJYsW99tuxn77JyrEVAaMCclMhr68E9+N/q/twc33Du/cMjMu68NbLir1qPPrtjxM74bQYS62nv9Ray3B1zpDbVy9y9U7384wYmp8bauPvqM4OXUObM3ePUfIQViuGzT/Zyly4OHTf/dhaXDP5qwH0uuo87fbMad/+OzNytMrh5YuvE+wSgvAcy693f6DlvT5C13yHWMPXea9rsLvJQG1FV74YvLP3BYMhEGWXb3D08BztbTUybLyUd8ndswEDmYQdc3UFNDzrJjAWNkBxppSBGb2EUVi8rVwEtPmT7zPOybOy7qGpWrkfYeqGsY7BnmWJk4yKQM5SFwRlULTR0k+fE4x8kU7BSC7Ko/CUJk5DFvFpd6c1G4XwVaDIXKFmgxZDMMavX7TaGjygGemc2ztpoHd/DXa6/AmgHgX05k9Sci8+n9I1XyGvsBeYaxzLRDjhi9XOx88kzEpusLnGfc0c2isiiHR8WKvtz94tYVnMnV/emH1Vgpe6d44RtybNbVsb74VIjQ0MKXE6y3J8OZKAeHxYo+n1axpIOUfPpUzzcnx2ZTuqKSM+QzplHZ8pZGclwMBhAmuRxVrODjQ1WRawbrjxuf5Lyxp3UElgw5PJqFuTZdZVHVhi68cviSq99ZLh1y4tgIgweUq93nf7Xr3K8EbpuQZW1K2LA8VcvYY8fZi24JXg4gppdiBKhq/d+4EE+/OJAqYHeceOQGr94ZEJUAWchTFJJ1dcx86LqIFKgoyWFsVLXy3+6r/OOBUNUaUShcgEiOu2rvY5IlX79AJCGzRIuzGQauS+84HUmWgn1FiTlo/b1pDJHXTXGWy9VaiHlnuA4AoK5FSRLqhopJ1MxyOSnJqgvv1M1n7h2cZiLDU86msq3C7/D2rwP5rhg7n/U8ds263GRXzHHMfwCKiEGBFkOhsgVaDNkMAyEjHR2QYTQgkrMjTVbU7y6iwlFVGlorx/NmsmCcHWPchCeIizoxxOgkALlRq59cl0AEK38xS2EJYhaqgZjOOSIkefbB83e8yYAmdqRBNS0XmFy767QvtR31cW/zEA2tcvv/DZx9qU+L6QrlPRv0XnfReomDMibXDvYd9vVQ0IBI2WRDNLTGzDtEqlju60v9cSRhmzH7qT+zad1+fIeh+8ZyGiv7aTEk+YxpbFqPd4Oo69W7Huw/6xI/MuUKZcOZvTdcEhHJffWtID8hGnr/Ny+q3vuQP3uO1XnK0T0XfsPvwKFr1mPPrj3x3OSUFHLdaVf/SJu/qU/WyZhYvloODCUk9KCqOC+90XfUWb7WEqGq9N74Uza1ez09wb4jT3dfX9YUvo8MX1kiPnu6tu0W/oSWDHvRy6EHQ4S6pm2z+Xpp/MC5WNEXfUcRnZfeSGammASY3hdFkrrJhpEPIYnwTgFDOTRqv/AqThhXBDK2ZkHd4j1B4bFksq72lDcNkcYqwcFjQSCjVWtS8jkzlLmzksauhR3qKMvVLTfhs3rX0xNEvcGPy+TIaBgIsh0/CKLwGM5KIrJztitPAY/v0taUjjyToX59j8F4yYpHe+HGihQVXlEyfckQQ4PHwokjl3UFQcpTiJ1Pctz19wSbGMwp3K8CLYZCZQu0GN5uTi40tIZzLziPLy7NW+CRpfoUDT2FokszM1JaYMkI2bJaierJOm0nfXedKFKlQwCoa1gqgRL43XIiVg0qHAKioqaiGTOf6SBAXYWI8SPiU5DTB6srXspID/C2qixq6vBPr7WfeTGJY6IeDKlikRDBB09CdJ/zVWXDmdSI7YUKd15fNvRfl0eDU1E5laEfX+G8+FqSnAp331yefiOIA2f8RKxe618Rydh529JBe0KAjEPdcl7Kg5eEHaUp550JuhrsrDt61V9Hfv4HL8+BhNt21CfN3Xcg2564F7X6rydHr77JF5UzOTCcPAPxt2Jo5b/8s3zb/d5QJFzt/Zt3fu2oRjd7Sbgdxx2u77yNdyJqWvWfD47ecHvqlL69X1mFV+56qHLPQzkCdNFPo6TSQXtp227hPZtMg+ia9eizQz/8TcqXnvPK7Q9UH1uYHjvNkMZRvvFOZ/mKUCHN9f/ddsQBZIXJOpOfOhHqWtvnPoFthleog7q2/GcHW4tCZJ3a9u83994ZvFlRuPvKktHrb4vcSx6iA4VbT74QHIoAzNX9nacdDY3mJ0hh7L5925Gf9CYB9RINj47+8Vb4z1LZ2kLWLC6MqkXlSmPvd+YaEjSaJieaerSQxhVUrTTcdrnGyYXg15YJgVqUrDMm9qnwpt1LhCLEsXITfpFlk1Xxk9dqLdUzoHC/CrQYCpUt0GLIaxjU+7yWjW1mcoct1A1y3To2Bx6NwAtJMmWNGHeW20xQJs6t8VCk5jlIGWS3BAAoA5o6tpl+UbiuZ61cDVBaEEDGtR51DQ0zYc8ddR1VJTJRsbnqVI0l6/T5NFE3MJmu1DvSNJKfYI2mM/rcXRd1089zRwBJ9fNAFYtA+O0hoLYl5p+YnbY1l8q6Qpk3t+Pog3zPkQANbeSXf0zeQEWFafM3U+bORK96SVHsp16wn3zOZ5OUgs+ZYe73YUjcfyKCyl0PWQ8+RZ5hJ4Xx4Q8q7904SWuFZNN6Oo4+OOQvMzZ2/d9DNDOqIlb2pRBcSqG8ZwNjr509OUlInqWQhvHKnf8Wff0JaSjIUQ6PdRxzqD9RkrC9FBSydjulQ/fRtp/v3Q4hyL7+kV9eS97rpynWgwvTyTqlHLvmZuxqT2DxQJUBZx3HHIYeiwgS6+gY+eXvvcuBlKy9VDpk70hX1LZPf0ysXOORHxKC+8ay4Imoq9V/P5WFVDRDWoxjTbnwjI5TjgptoCscdd2Lq6GmOoteXrb1J1OGAph502XmQfuQPVGHpJWGfvCLgbN/6ln05Fjmvh+accdVZCdxDKKmLtv8APul14Le69RfnNNx7KEplTOMoRm4ZYY0Wl06d085MhIan6W0TiDHKh360ek3Xhai76xnLUZcsd3hzqtvBVeSuJBkeHAAY8cFsx6+wZuo2q9Ujs4JmnqzyDpT49wE0HP2Sd3nnerdMmpG5a//XHnwScHL8WnTNlh8K3Ae3KRF0wjmbKBW6jv0pNG/3BGWc73GZV1BbuBR2Q5VbWRKSvDIschxqVoOUkzG+IlCUrWcssjaDupaurNcDxlOXmFI5SqaBo5Vs9bxenAFWeV6NUpFugI5FmpqZKJi0USyzvRTHAsAQoylUpLjhi7niklIReueJs8ZxyjcrwIthkJlC7QYshkGCkdNS/CHUFVj3T1ynPFS6dqfEJfbP55F7/jHCIG6BtLzonA8szENqHDUtUD6HJKo6+2NiJrqm5IMPTc2Ba4gEsF7yZSgmBFCknRDg2erEUBVAcYCToUWY95IScIffNKhFDUDi0AdxvuPek9Hru9K3QwqiyiWrLAeezbBuERFcd9YVh+10bbeHDWfG4Jcm3V1hHxSKfmsXv39m/sp+tLhM3utR57275wAVSWSKB0rp/v6MuvRZ/39LSI+tZtvOMt/TxCpXLWfXuwPhQhVG4RIeVpEfMOZfPoUT3hybXXTuc3J4SfiM6fy2dNDg2/+nnTiWETnhddkueKXPJiG7BuIeOtsarcyd1byaETkLn4tlSwiCkmsqyP4+EAINmNaAyM0jvSIAUD0AxMHAsCQu0cEnG+w6K987qzA5xnJcaOPmXNUuP+dMIzy7Q+s+sTxgYR8yadNnf3cLaj5GSGoKit2+az97EvBi5IrIPQhlJ2fP3jK5ecGClRU67FFK3b/fCTbP9VRJcfqueCbXWceS2XP6UQQMv1DGxcxqB+887QvTrnkzNDgMj6xPTS2rq7Y6bPWsy8EboeQKcEPLTlW++cOnnbNfwUGjxGSLGf5Vp8UK9YkONDkWN1nn9T13ePD/itDVQkEQDItidhmrjnqrLH/vT2H+5XZMIA8VTtkO+nhfSFC2VjIQIhQQr4QWVtvKhyCcjpWTHEiIubrgeMKsu0EJtd1gpD5BkdVSb8dmTZ4bX8/X92AzEMGvC4o3K8CLYZCZQu0GLIZBkTRVQMhK2cOw5SafZqEt8ffiZ2E+YeoVmSaOHjs/007CyBG5vp7iZWcRTeeYuTM2B0z9TAWN3g9cpcK1j/3jENlkTwvq0EmlUVNBSVsYguRJZZBlSqNVRNtWQJFibomjKFp+FtEQsQWfqCho2km1dk6LMYIZphyFgAAkmVH3ESyHRqr0FiAnJDz6PhENBbejkJEQ0PTRNWzqpFsO1NHmoqdEplyXdTU9EnIm9KKeq3qaeK5O9l8gPpJiEVeopZMOQY9536t/fjDgzwG5RvvXHvy+anuHutqT06JIsfq/Nrnu751XCDVF8hxaSTs3jJkXR2Rc+XwWGoF83i2V/DbIIQcHks5y9T7Dj21+tATwRtE00DDf/bkWObHPjLtih94sT9UFef1Zav2+lIkxjT9pp8pc2d57j+WzDXHfLdy+33BtIo66g29+u8n+o44NXmGyXF7r7tQ23oeWUmxBdRVbCslfSARyXZWLDhUrPQjBuRYvb+/2Nhjh2BSPJo6mkbSUAoXy1at3P1LIEXyOkxjDabne1fIchCWTDatmyaySbBkYEcpy4lyYDjZDyXpUDlMHkGAqorTusPHxexBsO6OLCV+0UVT4SwyeB3Q1KNFeQBUrtCo/yKRdGikHH0qUso1gxGVxc52Nq07qLLpARAEcFw5MIwskS1GOthusmk9KaGG+knIhnHJg3UckxlpQUiSawdBpKgssEwN2uuR2ZYV0l/LhMw6BalZpzLOJibyu7ElnZsrjE8ZiKpFHFUEIvAgL8skFhtnEZUFKaOzl5EtvjZaAiQDGX40zUVE8uzgDIDWE/tnETEo0GIoVLZAi2H99rBFRUtdHVBRUDNyrPJUtfOEbxhGPWgCstKHIseFANfVRPqOATSRV6+qsT1sc8aYZMwMN61lPWLQlQREYIwsm6QLMsBPqnA0jcaiUQpHXSPLAshhq9SVVMVeofFxgaq2sfv2M2/7TZI6IoKQa449R67uTzDIUFFHr7ut+uBTjRpM5Iqpvzpb3XTDhlhRUVXsF1/vP/lH6FWMEaGhTb3ifNbVkfDakOt0HPepts/s77eR0VR70SsrPvwZxAkXW0g+tWvG7ZdHKg74zGmNMu+S7ahbvzc0w4zR0OiaY75LFTtrWHcSoKo4r7619sTzAxnxBJxP+fX3WXvJfwM1dfR3Nw/912+QNaIkUrKujhm3/QqQQSNbwGjo5RvvHP7VH1Nb5ub6ykrJpk8xNpiRKAKCcNMpGpGJN5e7byxpVAQCoLFKwwY+QxopVx96MngaagY4qZlcUt10rrHHTlSZiEOZhugbqP7riVAP2w03MPbYIXLLWT7hUUjJujqMPXb0f+FM9g1k7IyVAkQaq1QfeiI0CVyddtUP+ezpXtwQTWPo/F9X//1ko+8Hnzmj9yPbAW+Qrdo0nYUvei9MAtbBMBCJVgEiiDqC6XgRcuXcNJom54GF02IkoaFlWfvIdcm2/IgPIggZ7WGrqVS1mkNMKWUousRZM7NPEENsIESoqWQ7VLUCDcUxD2eHK1BTqWoDz/b0PXCWMf+4cL8KtBgKlS3QYsiaY4Ba2nZXHOFCFkQ88UllyOUso6KArgXrTFDX6qg3aJx1Qnieh0G2E+WYcNyo/SDq+EfydnJEVQnPMMbQhxHRWIWE481WTGESARpaOCGk7lrjkyBCFUSum9OeCfOPAABVLGwzI0XhVKmGtp/q5ESt1DTqDeRK+ZZ73aWryJl8V1BK1jul82tHNRqrIuGae+5o7Lcr2JPbMYhyZGzkp9eQm7YHGDlPVasPP1255W6f0AEBuTLlh6eGHijR0EVXhiRnYO63a+nA3b1ADQnX+PB2wX1Rclx1/ryec08OMFdK3p2nZS5ypXr/4wOnX+DPsBTKezbsOO4wPx4iCUtm9w9PCRrxJASfPSMYjkBdLf/5TuuxZ5M5LFDhU35wanAGgDPWXsrx+NQtNmk/+qBQAxwpB876aeidIeo8+bN8+hQSPtHG2HW32c8s9uREVbWffD4Li2uGryzjlXsertzzYJLoAOpGczpP+Vz6aBFIoe+8TdfpX04i2uBcrOgb+dnvs3yMQ1AV+5kXh37++6BTr8/fYvaim/yEDIY0Wlk6d68g9QYBzLrrKmOvXUPMF7ZDduBD67rKZht1nXVc+HZyLTWMW48tsh57OiiAsf02HSce4asCEZp659c/H/nSU8UKxQc1pXLngyO/vzm55kl77yYbLP5bKD5IQJVq45ENoWyyYdcZx/kTpXDxxvKlm+4TObD9s5/gM6f5ompK+db7xm65a31Rb6QP5Lg5iaGh1lWiEtvLZRyc519wlQi5pIO6SuWK/72Mpd5wLLIdqpSjS3O9YZAgdkNyqkroWTgWGnWGEFE6zQcBamqKm+84qGs0VmlOoy8hQpybCqeqhboZSosRIhpLpvy0rYX7VaDFUKhsgRZDJsMg1aknALIcLBl+qnltKyFftJ8z1DXffFd4iPhtcqCmhggMdQMYq2+kgSXD904YxiZAoq6hGWjLgQC2m49rAw0dGIakykL+xRgaBgRJMInqGbjQ0IAxf3DNyNrxNBfqEy1iNjiIyKpGQhaoq1gyPCcbNaPhLi8TyKCyUmrbbK5uumFSIw1JrKu9/Kc7fPsda6Ug1Ya1ljOxqt96ZKG3dw+MycHh9Axdzq3HFrlLV/gnqlwODLUduJf/4IlYT9fY9X/383EZUNUJNuysXbF6/2Ni7aA3xURC23KestlGOTq5Vf7xgByroNehU9fE8r6UrVfG5JqBsf/9hx9IIQJdNffYERRfQYGx6l2PiKFhf3BDc19f1px93XpIqc2fp26+sa8Jrqt9YH5oTojQNEoH7QNS+qY/UfXfC+1Fr/gP0dDE0pX55ExXWRJOxxcP7jjlC4F2FFGgpjiLXln2/ihZJypxfDuJQFV1nn2573NnxrSjSNR+NLSRy64fvfH2YHyg8wuHTP/rrwM9JFTr4aeX7/zp6OCKFqKS5OrgeZcFDyCAnu+d3PXt4xr2txD7v/pDZ/nK0IY+U5AnebTIVeeF1/oO/3rwR9bescGLt6Hq17GgygfO+on1/Euh20ElNbMkH0g4bUfs13X2V31NwBr9Y+BDKySb0tV7/cWAEFwnl232Mef1JaFJyCtnNsPAdsiuJLmrjkJWBrLOjOB56Sb1sLPsWMBYSHLhku1kod6IXt2xcvcfRdPAbGl1IXCGPCCDkLEkmGjoOZlEcmE8vJMcuKiPbHCOupZnEuJQuF8FWgyFyhZoMeT9UDMMthtAVQHOSbohJwnBz6T2IAQFjiHv9Iklo8Y+SQCQGOgmEMAZqkrAsFOAKHgiAQBRdPDcDnWNL63RpQ0RhCAQENjtRoXXl+ZSOMkdGdZbWVjjfJCBWxa1biUNhDIIZCyHQEQqVJWJyojAfNbv6CKmk6fzuvuFGj9p5JZZFs8nl8oi0mjZDZBCosLFyj71PXMjPqC7bDW4Iug58pm9WPIdCBIOIDovv+mFb1BT5eCwuvEGyQ4KuUKuWuu8vMQLPKGpo6kHTyThoK6FB1fE0lV5Qm+Isn/QeXlJw/uxiHzWdJXAf66Ioq8/lJ9OxLo72JQu/4VHpKolVq4JiSql8/pSLOlBlWXTe9SN5zTUYJVcl284M7o3S+S+uTyYxYG6xro7Q/Pp2qynM3QiIpWr7uq1afXfLBqTIWIzprAguwJDOTQq+4fSK69ytPfAkjF23W1rvvRtnxTWddUtNpn16A2hBGEhli84TLy10vuwkWNN/9Ol5id393WozRw6/9eD518WGMo299pl+m2/TlYOVJUVOx9pP/ui53WSa0/99bntXzzY2zzEkjny6xv6T/mBz34KcTXo2ZEj14lo1hP/q86bG+Qx6Dv81PLNd0WpNy76pj/Dhl6995FV+3856gUSBOOd5Doz779G336rxikTw8xFNeqNbQ8VK/t86g3Xnv7XX5of3TW0ax2eATT1yq33rz78lNAMxyI87eRY0678UdtnP+4/rDZz5KfX9p9xYarbvW4enC8HAgBQmJdhsgccPMyP4+Kkx0w2SO26CSdONnhu5B4nVqocxyCEEx3ipj03ajxrjT6I8XNzzUyWW65D4X4VaDEUKlugxVCobIEWQ1Ob2wctIe/f+SyteqOq/oDsCDu5cQdAtPIk/rDGj0m49yzTknIMjYsRYQGrR+pk1vZXszys4FCBoEcDZ60bmqOyqHCxZMWKDxwWsqY5n3bVD9j0KX4uOhGfPpWqScXNqGjWo4uWb3VgGgECiuWrY+K+AVClWjp4L2O3D/qBG02xn32579Pf9E+UhCV9xt9+hT2dXtARDW3N579tPfZ0MI7R9Y0vtR/3KZ+a09Arf/9X/2k/ChwjlLmzpt/yi4jkfPb0YK0LVao9F36z+/snhYJcXe3BNHaybG3BlrOfuiklrUJV+r9+gfPyG34xj2t3n/PVtiMP8OU09bEb7xz87k+TnHoiUJVpf7yITenyI69EfMbUYP4Alozhn/xu5DfX+7csHH2HbTZYfHvyMwXGVh/8Nfe1pZnaX6ahSV9ZRLId55UggwYB53zODGXurGDgmty08nZEqlTDQ01yYH1APgIi1tnGezr9U3RVDAzXfyyVjWez3h6/XNHU0dAj0Q82pVvdbK4fhzINe+a0yDGocnXTDaPUG5FKQCI+cxqGs/RJyFCUnggNXZ03N+nuAFBX5eoB542lHhEEgZDDY5EPIY2UnTeXJ5JFEGoq33CmMqs3mJYVfViIsn8oOBSBUDffRN1so5SykRp3dFPCGs00DBBDSQ9EwDm4ghy3Yb7myFDrAkmh+k+GscJQTU5vNVB4zPxKSY7rF58obkwiIgE5GUpVhaDUKSFKL3RhCJwhMH+6nLqSFaixjUDSlBKhoow/rOTsyvEGucHLsdC0xCILK21mFO5XgRZDobIFWgzr0Nwe8lBJoq6Fal20uNYUQpKM7kDWD07hqxPUKnDMUPGJ467Hlqr11BtVG9vMlAIKBKq1IA3+piqgqcH+KSBktL43DlS1gkwiBACsNgkTI+kG6nXZGpJIhB2mbNQb5LjRW3bd6JzHVcZTxQqSfRDUkmj9E1HLwMcPADnJOi1H33VB77U/9ktWFCaWrh4485Lk0gjU1aEL/sd+8jmYcNiRc+fFN4IZMCQcbestur5zPPhUA0wODg+cdiG5IdaJnh+frmw027dNNW79a+Hqg07wlw7XNfbaueOEw1P82Vwg29F22Do0CQzlyFjfYaemkNK5bufXj9Z33sZ7l9DQyn+9Z+wPt3rTAq6rvm+z7u+dmPy+kSN6LjgtVEijcfuhZ1YfdIKvCpy7S1aEZ1goc2f3XPB1cD2Hj4CxZLpSAKCq3XbEftoHtgiUKjGxZFVozoVk03qmXHI6MOa/A1JO+elZcnQsKKf1f0+u/ssd3onIufPqW8m5UDXk+soKwefMbNt0w8DHUnGef23gjItTTuS8+u8nK/c8FH6m4WR1KfmMKW2f2o+qATaHFX0D37wodJIkc59dtG039zJC0DArN90zdvM9wUIa1tPVnEKJegjBZ/e2fWq/0CS89Oba489JPo8A2g7fHzgHLx+Rc+elN8Zuuy8oudE3CPykFBmkNPbeMVSuaJjV2x8Yu/nuJEoLKVlXW9unPkphhp50zkYhtPnztG23CFxOr9x019rTfxy8HJ/eCxd/M3zPZH5011DNpmGWr78j+LBqp64vSuSa9FQOMjopWVYxgGyEC0JSteovLpzXV5ZCbU0sV4O8LxP+rF9Ik3GtyQkhQ8EdVyHLTicud6z6rNA6ihArY7Ou6AJSPwmxkETlag7qDXLccG4ukStCl3NFDGlI7X2IyJm3XKpwvwq0GAqVLdBiyGsYKDy4cqGq5ObkigFnaJh+SJxzNHUqVyjQMYJgonOiVySjlSJNR2pEG7l7pUaAmoqamXRA7knAOE/cdtAohdxZonRuMoQIzWg9anwZ2Gamlt9Q1crQIy0aO4oVEk0jVHavmbkrmnKprKo4L7xa+fsDfv0GY7KvvzmpD4y7b64YuvDyCP9jx9c/H3EOyrfeV/nHA35giCPfaFbXqUf7ii2Fvv3WSTSgjUhVve8xAkoajTG5djDP4Larb79V18lHhUhFFXXov34VuBdCU28/+kBQOST4SLZr7rsL6+lIJesc+tHlyUKRcEsH76NsPDtp89IVyiYbhiSXxLo7opqAOHrFn8XaIfSMeE1xFr+WLORkyKOyqCrOwhcHvvfzGHaMdQZyxX15ycCZofgA7+ne4K17gvvUqKrLtjjAfum1oJc97fLzO479dID3E8F1qWqv+4cWuVK+/f7y7femH9n4JJDlGB/ZzthnFy+bDDWjeve/V+z9xaDgrL297cgDUEtqm0GWUzp039IR+0cT04ISapr95PPLPnhISkMTAG2rzdV5cxPa6ZDjKlu8p+fiM0OXq60GQSEZG7roSufNpXXUG3nUbx0MgybpaAyirBMCTYPGKhDcvlcd1LUQ64RjgZBklaMLU7MMg/VHb4F1nriQZDuhGRYSS0lmiT+UZUNyIxDHJctOJ8KIi2zEQAgaK6celZN/JA6F+1WgxVCobIEWQxMbgiKqmaLfUbiCKM11tR3UtWDjO1QVctzo9nqWFo2Sou09LIa6hobu58saev3OM7kupKcMxkwCOXaokhviCCwUHjTs0NBjNkEQ0NDQ0IM5DGTbkZSGGg1K6EQhorsGRNH2HoCoqM1xoBFRV0MGGefkOJErIlMbpRisYR26K+68rZ/ojkiVqv3UCw3fM0m+0Wxl49lJ2kaStZesB54Azn0HhTPtfZuyqV3I/Lp7PnNqSoMKSdhRMnb+QLAhKGiK9cgzQUIQ1DU5NAIYDDBJddO5fM6MJDkRqWrZT70Q+VnfYZtgwji5NpvWE5KTM7FkpfvmskD1hGY/tTgkAAI4ovp/T6ARaFhJpL1/c+wo+VrLmfPiG2LVmmDJA58+VXnvRsHaEGwzjZ0/GKoRILKffD5KkJEDiGTZ1kNPhxwyZNpW7+Uzev2IAWfO4tflmv7QPWZD/h625r67+CKpivP8a8u3PaTRDX1ynfYjD+j+4alUndyE51ws71u2yb7BZG0C2ODxP2sLtiTbdzXIdpMzYMhx1XlzZ95zpf8TQxqtLt1kXzk0FDwSuRqkkiTX6TjusM4zjkuQE1XFeWXJ8q0OilRiTbvmR0HqDQAg2wkVqBh6+cY7+7//s6TEAMbk8Ojqg0NZBwQw695r9B22CiRa6MOXXjty7V+DgZT2w/efdu0FXj0FOa6y0eyZ91wREB3JdpZv+Qmxom9dUzI4k2sGVu1/fKTt8gZP36zOn+e13EGj1PeZ08au/1sOD34dDIPgvn+EZLQRkOuSXY3NIhgH52TZaOhgM18bHJdshyrVhnMLZZgLmyFVLdS11HWKnDQ5XRH7wlDVpoqVsqGfJQKDWEch6tTXIKBal65QH+uIEIIjku00rXAAEXU90t5j/GF5k8BYo422PRTuV4EWQ6GyBVoMeQ0DxNCSxBkwBlL6fiJR/iB+7OBCgpABMzHbshIZCgAozmGvh5Qx+0c8kU3SkzOVVaAetcOS10qEmAz6GsFlwK0ZF1uE6nVTJEcEzkDK0BOMFb5+PiOoTUI9anLKoJx1t8zSyCsAID9Zp2UHuwagqtDwKJva7RvvRMB4yu3FDw7kODQS8HI4l4MjbGoXBXthOm56iASRqnaUBF3hrKMtVQrW1Q6BqBO5NhDJvoGExJTxSZjWHVXZ1CYWRGjqrKczNclVDo9EXiQ5NCLXDPruV7kKCmdTuoIMDKCqyZIDIjku6+4gx/WZD2tGcIQgsVxNSYxWuBwYjpF9cFiuGfTpH8tV1NSgnDBu9KdzoebKMTD18i33rj3he14MkhyhbjZ39nO3RL4TaGiNVoSjrlcfeKrviK/7AU4h+fQpMx+6DtVQLTzqWrLvhaYxet1tA9/8cUBOV992yxl3XZ7MbkmONfWKS4zdtvPcKWwzBr//y6Wb7JMQeyZHqO+ZPfvpm6KMloaW7HtRudr++QPbPrN/0rrEmVw7uGLnI2ms6n0IUFXXfPp0YMyLKJFj9/zotDkX/jPAWKqP/fH2ZMmBCFV1xn1X8yBPChDqGlm+gmLJGL74qqGfXJUSgK+tYxiKy64+8OTg94sce+rPvjvlsu9Q2aNtNUYuu37gOz9Zb2SdrqBKFezx2yPhjuezRargUzsfxaLWfWli8FrPbCwZUfqGLIM7blhOJ2v1hKFjm+l9yLHNBKKQVHUg4VLVxjYjup5mkVNVUEt8FpxhOSazkapWKCNF2MAYtpl++WDJAMaSJQci0MT4LQefYJ3kNcc/aSiAcdLPVDl5Tc6J169tfZYrjosF4L83AgERJOXU0Vh4g1Ng8EYDMbUZiciZBUSh2/H+kWDqeJOQizk5KaUQAHCSYWt0Wr4MAAANS04ADKO3HC9GeD6zI4uc2eatiBgUaDEUKlugxdBUTi5dAxHwMzISVHGOmgZelw5dA84JABzPQ5KxbhaqKjBMymWu0XzEyumBITiCbIek44VgJoghNKCJRBlNm2h3M6nfRiDJcVFvCl8a1ijAUo8jxwXwI1ME0QeButYUvsFxjJfNrCubyQRFiOaZzqjFPaw4NI+s862VK3f9rK8/RMBZ73UXshlTE8KNqGhj19xc/eeDnk1D0tG2mDf7oet9NSVAVcEwtRsqfM3R33JeWZKU2c5QrBkMhlFQUZyX31ix05G+CUUEutp73UXYUfLJOjV1+JLfDZx5EbKJ3iHSLR20z+xHbkjIYUDOxer+lR/63LpnlZNrawu2mvrL7yZvg5PrTrviPHXLTfzgkaGNXXPr8gUHI/NqnFD0D6W338giVcVqP/Yw8xO7r3vCFxra6G//PPzT34Xk7BvIImfzyDqrlvXEosDTIkCenhmEKFb0uctWBr4Tknd36TtuQ5VAPQxR9EOLaD//ir34VUyybQiRh95dRCpXrcefDcqJhqFtvRnr7fHfeNMQy1dbCxd7gxPItk99TN9hGyonpMWozstvWk8+1wSVBYmltnQvh0jdchN9h609zcZSafTXf7IWvhCYFgLkzfnQSslnT1fmzkpY2TICS6XhC6+KyBl9WJOguWSdgVekRtaZ5XXkPNj1DhyrlgeT2hgIVTVP+9aInJJQU8dTq7zVgDHgtTyVQJUOEdmJUkkix21O1mnmlrnkuKG5UmxADEneXAiR1DA+OxR7giKkYTkL96tAi6FQ2QIthuYZBjH8j4Cmjm2mt2eLmpkpg5gzNEohSy4L60QcMlW/lAlNA9tMv5BGM/LVeAARuVGHKZ2la9zxDzC+15NY1QYfq5BwvAPja3LyAktGzP5l+BCwbbLdHLZ6HfVG6e2l3qgDCclnTu361nHhvRMa+vGVEORrURRn0cvJDVeRK87i19cef7YX9gJJ2NXe9d0TMJYPPkkq1/jQB9o++/EUs1jKwe/9ItRrV+Huy0saagwLACQkm9o95dLvhNwvhKEf/lb0DeDk7wAJ19xn59Kh+/hySsFn9oaCXJKwzZzys2+RE0idllLZcFYCz0BWIJKQA2f+hJmGF9eLlbN0wB7mAR9uuP8oY4Pfv0ysXONPgqLYjz/X6AyPn5rjnBhIybo7Ok78tJ8EgwjCXbrxvmJ1X/BAZGrKh5ZxsXT1yG+vD/7Ge7q7vv1lSGpQESuV0LbcpOP4I8mqTHoMRxqtLJ27txwJ5R8hVxvmMpGSdbR1HH9E6EfEkZ/9Qaxam/TZlkLbZvOQnPWUyERo6O3HHBp5H6iSgYMom/Bj192SfAgB8FkzzAP3gEZVFnHs+r87b74Vod7I96FtqmEwVom0XUZDzyNZHPVGPqHIFWRXovmHQTCkchVNHcdyFnyGr0fRayFmZcdOlhPyW0cZkV6GlTmOETO4qRfUGwX+P0WhsgVaDE1tCJoBER4KAIihG69r7zGRLxvY9B9PMIgM7kCY0BOkRM1MWpoZAwlUsUg6CbU543v3oaEQRKa64khni9jBM9UJI6IZWbuRqlZ60CADuUkW0HhkIwzOUNdT9sO4QpadPAkAEK2DnwRvr8pKYe65M99wpu+lqdx55iX76cUBtkfBZ0839topUM5AqKlj194aipJwLgdGQjUqUhgf+oCy6dyAC0hsas/IlTekzJSQpUP3AcdJ2mhFoko1NJQUyoaz9Y9sl1p2UTpsX7F6LU7udJJw9e23ShkHkSy7fOOdFIxsSGl+9ENsWneSByaFMm+uvuu2aeqSDhKuts3mITk5F0tXVu9/NM1VRXOvnYzytknBPpU7z79mP7Eo1et9W1WWhNv59c+Zn9iT7InyCa009INfWE8u8klfhKu+b5NpV//Y59ysUW/M3ZPCn0HkalAPSLjtxxza/oXDvBNRKw3/4po1x3w3OYyIijZnyd1sek9S+o5W6j/lvIHAUARQ2m+36fvsQm6Kz9Rz4WnpW7hOGqkoQxotrz3hXBL+95gAZt37O33mVJpcchKuscu2U6+6kOx0fsJ02E5QTtQU55mX1nzlvNRA7QbP3qLO34wmTwFDrTRy6VVrH12I/1EqC7WStGolyPsQsyYKSdVyuL1HFUsmpCXZkGWHyDoJQMoUSgtJWDKoUqWxSlqBK+bswJHRzU997IjYZsJYoMbVcdJrIcfDJuVgeek6ISInz0AaIgRVbRorp9TAZWNRKdyvAi2GQmULtBiyGQa15uReHrGmxmf7ayoI5v0JgtWv46hw1NTAbn7cZhirDTVh5vP4EDQ5btBRjd9wl7Iuiz5vG/JwQv5EOEL1N5YBMrX3XgeQ7ZBwQPi5xVCbT79dnprFVMjdi52ESN9sIyI3MgmyiZ3CM8iNKJavthcu9gxQNDSxZEVIHRHJsu2nX/SVBhGEIMeJHOa8sYwvXOxTRZi6WLkmOtRI2V642I8f1dpmRO6ZSH3vxkHmSnId1tMZSnKQkk3p0rbc1OcwRKSK5b6+tOGUVin5rN7gUCRc1tNpP/WCLycRaqqy6YaNjZwRBMCZttVmVLE8W5aEEG+tsjWVHC85XZf9Q6lp9VS1nOdfzcOsOn0q652SFFYjQlVVt9wk9KOUQW7gdQSqWdgShaSwlMgw+nUkqs/PQEWJWuuuoAgzBavj3okdKvxVIMed/ej12jabB212EjI6m4wF81FQV6uPLVq561F+/E8Sthmzn/pzSqgIADjDwAcMTWPsT3esPvI0nMh8IBDqRnNmL/xLE78oEUQmAXV1xfafrj79PAayLzBMMUSO1f7ZA6deeb7nfqGm2k+/uHzXz2CDORsEouc7J3adc6I/lKlXbr1/9eGnBLsr8rkzN3jmJuChHCZyRfK0YJs5cunv+8+4sEnUG5wlJCJNXDPbWqPw9Fc721DkCnLclIVYhl82ho2y1/gQMhRLUtyJcMSEqA7ka7GSHdGbZQicI7CGV3nEPDv+jshkddTKVPPxOWRA4X4VaDEUKlugxZBtaVhvxlkDqPcVEMf/S0aM8IE1iwiIYobKfsv+kRNDpQqQnWQp+cTxzMa0JbghwtCEyzUX9feS7XLZVFZR0CMEfYdQb7OS41CtrmPyk5CxqJuIiKrmm3Feha1tg/CVDxUlfQYZoqr6nhxjoCr1DO6o1FUaOy5RmMm1TnJAVl/JXbc/RKAoqGlJNjQSZLOwoyxuiJmYU3LDdSlIZ6twiIbG4pHBy3Hs7m+d1H7cYes1vzgJnMnV/av2PibIioCq0nfYqagmdsd07PYjP9H949M8ycl21C02mb3or/5MMYCKvfqgk2lwxA8eOXbvdRfruyxISNSiqmXssePsRbd4Q6HC3bdWrtjmkJAqEky/87fqxhv47BimsfbL36v84/8SeT9tfacFvTdc7DN9cCb7h1btdQyVLc+aI9edeuUPtPnzUt5bQ095dkSoqTPuuoIFyDrR0NccdUb1gcdz9sZKBJaM/pN+UL7lbn9wRCpXs1wry/tHrLOdz+pt2iZ1o5gkB0quGUzOeSPpyqGR8HIPqCp8Zq//C0Maq8i+Abl2wHOHSbrppCFEaGi85A+FqiLHKmJlX9TAiMTOEOXgsOjr94lSYiWvD69KEqvWBPllSbqsq4PP6k0pxiLKUtXIpk/hM3uD/COoa+vOshEPRDk4Ep0ExCwRiWyGgZQgRGLt5XpGbMQ0Ne4m3ZgpIArdCCEICZwB4/6A0s1kV0WGYghSRglHYheBmlQJNXCxktdO4QFu9BpVfLMejQgPJVIiqeuK1EmY7Lzmi1KgwPpEobIFWgx5d2s4R11dL3ZOrR46S4GKk0Ih7xfSJDBTcwQZE81BXUPT8H9HANuty/bIBDR0LBlge+yZ5kSGTVD+ur0oxtAwAg41Q0OnikXCDlJvoKZiyfAz+RHIdvLt8KGpY8nweVKMbPwjdd2MY6n90dCBYSB9x4xrg7zeCmlQ16r3PDJ08RXBlpnNArmOvmB+9w9PSeOpFFN/frayyRyavD4ENcV+6oWVe30OkxqlIglJI2OhKh1FHTjzJ6yn0/NayHXav3ho2+H7ZWy1EBge1x5zNgYoLYhk6YA9Or7yGc/NR0Mr/+mOkav+7M0nKqrz3Mur9j3Wd5skYEnv/eNFoCr+g1fYyKW/H/j2Gi/5gVyn46TPlg7YPdiWI4uQ5Io1nz0zRI7LuL3wxeRHTJajbT9/xk2/8FvREqGhRUvhGVt7/PfdJStRmZCTZOlju7Ufe0hoEm66e+S3N6QqVa6vLGdi5ZrK/Y+tj0AzAYCMa3AVPY70XRZo226e4CyjWXJefatyz8Pp+f4RDiJk1uOLIpWP5h475yM6qP77iUiSZMdxR5gf+4jHRoqm6Tz9YoimBZkcGK7881/BcVhX17Rr/gvbTS9+jIY68K1LrWdfCJX3HLh3HjmJqg88FokPIE9LZZSSTesx9/uQfx4CEEVZeBGr/3rSeX1JUM72ow+KTIL7wmsJXDUechsGLL18Ih8cK2NnErJsqlhJ1ReMgaR8ckZXKMfKzSEVjTU6FghB1UADLc5iknsYQxbkH5Goa1S1gbMAn7NEVQkxljpW7r7JOeOvUib19fUG17VQIo5jgZBkpU1CHAr3q0CLoVDZAi2G9UnWmRWNM3HHggCNUIsI1EqoZ7Mx6oIPqb3uJxkohqwzekitmijARopaKZMthIhtJrYZnmGAmkaWTSA9v3uibUYptGnsimjFuZQZiDBiJCcnA1MnIpbCHGqcUzVEvUEAuROXm0fW2dvTcfzhDe+XaIp132OVex/Jx9sYBOpq+c//tJ/xWTxQVa0nn08ZmQg1tfOUz2Ep0BVR5WNX3+y8sbQhqUhI1t3Z/d2vpOyccbQWLrYWPu95d6iq1sMLU67FkMrVofN+BcG0CoTSwXuVDt3b9344iuWrBr51YaAFnNDev0XpkL09o5+E4DOmdn/7xPS0/egNusaHt0vZHGZMDo2MXPA/EU1oP+rjwWkh4apbb5avTq55ZJ1Tu7rOObHRnUPUzCG4rHL3g7DOKguaUr7l3tEb/x7Wl7RPOAEovPMbR7PenkARpV6951HntTcbk0pK1t3RdfYJyUehVlr18ePKt93bmJyIVKkO/eTKiOyzH75e33EbTx1RK6394hnDV/8l5Jsf9rHSp/cDz08VkvVO6f7eiVnvKwjbSaFEZkgjY0M//m3k5w2evUWdPy+oo2TZ8E6qLNSRdWZGRsKFDAPV3NI88QEqh6k3pMxJ2kqUnjxEgEoGuop6IEZPcRyyHCpXQl8+Fg7m1ChCIouflPmTnLIYBroJIkDdPE69UWlK+XHhfhVoMRQqW6DF8HZzcr3diOGpxPqYORo6moafKmoYmUpJOUMtmFGKQDKh/aIHsp267fV61MlZF44gAFRVNH1pUTMm2Eb8GEJG0wsNHTCpwSoAgpMz0aKJeFerLEm+0Sxtq8287mrImBwasR5+JpTvImTljn+zzjbfy9ZV2T8ISZkJ47vW9sLFXgIDkWQlU991QYpUQujbbQWuA5NvpiNjYu2Q/fizob17TTX23BE497VKSvvpF8XKPnAnLG9dwe7O0n4f9k90HW3BFuk+BlHlzgfBshPCHURSnbeRMm/uO5k5/e5WWXKd0r67TPnND8ga56lEXbMefXbFjp/23XNEsp01X/pW5FzkanJ+Bmqa/fAzq48+M+ibq7NnzX7u5uRIH1l211nHhjSvfnDdqN770Mo9v+B7UZKwo633hktCcVldW771wdaixUEZpv78nCn//R3vlgEQXDfl249Ijrv2i98WA4NJkgN0n3V897knvWP1KQDw7lZZAK+9x0TlkxDxqXH5kiUiPJWOW8eyPYlUqamVsi6zBGC8vQeCvxoIgZoazTGQkqxKjkI9NA0cUpJSFNahvUcTUbhfBVoMhcoWaDG889/5ZqKWEO0GNrKJUOE0kXiACgfGCCRGNrjrEwtFiF+SJk4PDYVIAOhfToCQUN8Csn4zncfQmAYxIac/OJAEIUDhoHDfMKhnSAAAxsYP8yDrKmwRQxkUiONlj1IkBAzqJwEgroQ4FpzHzEwQCs8UpXlXqSwRm9LFZ09HZTw2xISDmuq+udxL6JSqIvuHlA1m+hv6CEAkVvWHHioRmz4lyC/JhANShobSNSpXlA1mIFcnjhFs+hSxZGXIryLgM6aAwgOhMJRrBqhiJWit1FQ5NBIcHCSx7naxdBWauicVakq0eB1RDgyJN1dQ1WPfJyyZrKczkJmA5DhyWX/gRCTX5TN7QU3K6WbCAaLgJNR6PrKp3am5JWJFH2szEnqXomnIgeEshc3vHpWlcrX7vK92n3uS9wuWzJHLb1w676Oeh0SOoy9435zFf/N3OBnSWHX5Bz8l1wx6Hx5y7Wn/c56x+/aer4Zt5sBZ/x0eyip9cq85L9/htUREVXFeXbp8waGRovBZj16vbrphkHqj/xsXlW+5O8HnI8cyPrT9nJf+7isHZ3LN4PLtjwjyGAAASBmkikFFG/rBb4Z++NvgUO1HfnLqFef5DJuq4rzw2ooPfc73pYhQU2c99ic+c2pCAAvbzMHvXRaZBPNju03/86Up3h7nqw85JekATwylOdQbrYMId0PN+a0teTVIAUTAOfCJb2o9Ue74uThOGjDpUHJiqMAxHEN76zAJj0FtpU6IbsYMzoDzcZ4BCn1Wo+dGiDbkJAzaUnhs4EAEgo1fIgGxkyBSvq/jyBLKbSYnVwsh+HgCS+HETzj+u08jN4lWUeSw+qEmfg8x0kEmOjSMGypGhgx0d/HjZ3n2GLEoxi+RsMTHTkLGAsDmMdIVEYMCLYZCZQu0GJpqGOSo7QwyTDWKGhEnT7Tban/6hlRdM4UahAQpQp4+q7Nlcy9tNRvRi0zFDlXP9CbrbVk2TptFDUpSb3PHE35ls2UhbJhONp8Rmz5v3W89mqOyqHCxZMWK7Q5vlCgPGRNrB7P4ifVXXHPk6ahrfrMQ1+4+92ulg/f23HyqVksH7anvsi1OzB0RMUMPUVtKQkOb8c/LQ8FFXR08+xf9J/8AJmJMyJjo688hJyD2Hfw1VFVPTmTMXb46OBS5dvvnD+48/YvgxQc01Xn2peXzPw7BIFdn24w7L2+4tYuhVe96aPmWB3gVFohIlh0ir0UkV6z+2AnJmQ8g3LYj9p+96BaojG8mExFrM0N74ELw3imzHvpD6ETOVn/qNPe1pfWMuTnQpK8sItmOs/i1xs8kDFIONnJF5/Wl4QCokEMj4QAQse5OPrU7fMG6djeI6mYbhX4wDdk3YL/8ZqBnC+FkH6c0OK+8Ff6BkCshOYnYlC7tffNobCJ9xzDEyr6wAJJN6VY32yiYFpMF2GZaDy60X34j1H8G6zqREDkvv5k8FIFoQ9Tmb0ajfjtcIgrtlRCAytUt3hM6s9Y3rkk8is0zDPJ2P8t/wcikx/ZLkdH2T7GIFngozgS3SBPuKNMgUpLj+GJwB0S43Y2QqCjkuFBr9pIdtgNEWe4lXU5HQC3ZN7kehurms6ndaQr3q0CLoVDZAi2GvAufW0832RwQxLM9xhwZvjoBAK+xTqxr1Bo1I7XWhQDIFUGSC1QVNPRU6g0AQBZNS0VVQc0MCKCjUbedi4glM2LLUsVKJZWnuIdVv12cifwUALVS8mExqKPeAABEJR/NWXpDUHKsKRee0XHKUX4uOudiyXLrkWfyuSMpkJLPmKbvtl2w7bJYuWbFgkODKSAkRM95JytzZ/mlSKpiP/G8WLayGUuH0HdcwHp7krYZFS6WrbaffM6/nJTYZhq775AcNkFdG770WuvxZwMpL1J578batlv4fgxncnV/9f7H/BkmQl0zP7prMMOGhNt9zlfUTZMYS4Fz9/Wl9uOL/PowRXGXrBg45+fovTZEqCjdF5zKujuSXgBVcZ571X3tTaAGZ5jI+Mh22NHmDY66NnLZH6sPP+VPQmbk7JnN585uC3vZzUQWSmRJ5v67adv6PWxRL6257YHR//3Huu8MEkDHl48w9t6VrEmzPVA3x264rf9bl4QKaebMnnr5uSnNWvXS2J//CY8+7XvwjDmLX3NeeDlyYKhcEZEse+wvd0Tk7Dz5s8DmAkyuskIom8wJuvCoqfbCFwe++7NQC1uGpUP25rN6k9Ji9NLAmReO/inPDHefc6I6fx45/sMq33o/PPhEg210AfIbBkJQ+Z2sWQMAqlpUrvrlo4hNoxB1LHJcqlSSTBQCcEW0kEbXqFxN846xXi1QUdKfRRz1RqaFzhWhuJ4bX01EFYvK1aSFBREA8sywEGTZVA5Qb2DMJGRE4X4VaDEUKlugxZC1VWTQn327wXmU/BEAANDUsc2EiQA4amZuou2YwQ0dTTNhWw61Wie3yK+IbWaKLauZTdxwR1PHkpmx5eeEAGpsJTCWDGwzk2xZzcy9tzL+sLw893V4WBkkYLx6/+OEAMksjesPjMnh0agny9jYH/5WvfdR38vWVeeF1/zeLOt0RV6+8U776ReTqPk01V64OHQ5xuTw6Milv0+xZTXVffWtJsnJxv54u/WvpxrjalW4WL46agRLOXr5jayzPSlioKvWY4vySI44es0tfMZUP5FDV92X3sg3CelBLgAgxwn2unhHkCmOiEpTEi/iB48TKpWDaJLTcoYk65FNzjgZGo/LAkBMs6dsiCGdXn9x2QIF/qNQuF8FWgyFyhZoMRQqW6DFUKhsgRZDobIFWgyFyhZoMRQqW6DFUKhsgRZDobIFWgyFyhZoMfw/Dy4IB9jYiVYAAAAASUVORK5CYII=" alt="QR — Cancionero en vivo" width="230" height="230">
+        </div>
+        <span class="qr-cta">Escaneá para entrar</span>
+        <span class="qr-url">haciaelocaso.com/presentacion-album-mdufc</span>
+      </div>
+
+      <!-- Otras experiencias -->
+      <div class="extras">
+        <span class="extras__label">// más en haciaelocaso.com</span>
+        <div class="extras__list">
+          <div class="extras__item"><span>◈</span> Creá tu foto con la estética del álbum</div>
+        </div>
+      </div>
+
+      <div class="sheet-divider"></div>
+
+      <div class="sheet-footer">
+        <span>@heo.oficial</span>
+        <span>haciaelocaso.com</span>
+      </div>
+
+    </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
Nuevo archivo `folleto-doble.html` — imprime 2 folletos por hoja A4 apaisada.

- `@page { size: A4 landscape }` — 297mm × 210mm
- Cada folleto ocupa un slot de 148mm × 210mm (A5)
- El layout del folleto A4 se escala con `transform: scale(0.7035)` para entrar exactamente en A5
- Línea de corte punteada entre los dos ejemplares
- En pantalla muestra los dos lado a lado; en mobile se apilan

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_