### PR TITLE
index: Spotify link, show 24 Mayo, bio actualizada, quitar player

### DIFF
--- a/index_new.html
+++ b/index_new.html
@@ -95,8 +95,8 @@
       </div>
 
       <div class="hero__ctas">
-        <a href="album.html"
-           class="btn btn--solid">
+        <a href="https://open.spotify.com/playlist/6So94YyGUL4HI45JjLzbAp"
+           class="btn btn--solid" target="_blank" rel="noopener noreferrer">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <polygon points="3,1 14,8 3,15"/>
           </svg>
@@ -220,10 +220,28 @@
         </div>
         <div class="show-featured__info">
           <h3 class="show-featured__title">Hacia el Ocaso en vivo</h3>
-          <p class="show-featured__venue"><!-- Venue por confirmar --></p>
-          <p class="show-featured__city">Buenos Aires, Argentina</p>
+          <p class="show-featured__venue">La Tangente</p>
+          <p class="show-featured__city">CABA, Argentina</p>
         </div>
         <a href="https://tickets.latangente.com.ar/musica/hacia-el-ocaso"
+           class="btn btn--solid show-featured__cta"
+           target="_blank" rel="noopener noreferrer">
+          Entradas
+        </a>
+      </div>
+
+      <div class="show-featured reveal">
+        <div class="show-featured__corner" aria-hidden="true"></div>
+        <div class="show-featured__date" aria-label="24 de mayo">
+          <span class="show-featured__day">24</span>
+          <span class="show-featured__month">Mayo</span>
+        </div>
+        <div class="show-featured__info">
+          <h3 class="show-featured__title">Hacia el Ocaso en vivo</h3>
+          <p class="show-featured__venue">Niceto Club</p>
+          <p class="show-featured__city">CABA, Argentina</p>
+        </div>
+        <a href="https://wa.me/5491124564111?text=Hola%2C%20quiero%20comprar%20entradas%20para%20el%2024%20de%20mayo%20en%20Niceto"
            class="btn btn--solid show-featured__cta"
            target="_blank" rel="noopener noreferrer">
           Entradas
@@ -268,12 +286,6 @@
         <h2 class="section__title">Experiencias</h2>
       </header>
       <div class="exp-grid">
-        <a href="album.html" class="exp-card reveal">
-          <span class="exp-card__tag">// escuchar</span>
-          <h3 class="exp-card__title">Reproducir álbum</h3>
-          <p class="exp-card__desc">Escuchá el disco completo desde el sitio. Sigue sonando con la pantalla apagada.</p>
-          <span class="exp-card__cta">▶ Escuchar ahora →</span>
-        </a>
         <a href="presentacion-album-mdufc/index.html" class="exp-card reveal">
           <span class="exp-card__tag">// en vivo</span>
           <h3 class="exp-card__title">Cancionero en vivo</h3>
@@ -535,10 +547,21 @@
 
       <!-- Bio -->
       <p class="band-bio reveal">
-        Hacia el Ocaso es una banda de metal formada en 2014 en Buenos Aires, Argentina.
-        Con <em>Amanecer EP</em> (2016) y <em>TRSCNDR</em> (2020) en su historia,
-        la banda se prepara para lanzar su tercer trabajo discográfico:
+        Hacia el Ocaso es un proyecto de metal alternativo argentino que fusiona influencias del
+        metal moderno, el rock y el emo, construyendo un sonido propio que resuena con las emociones
+        más profundas de la experiencia humana. Sus letras exploran la lucha interna, la búsqueda de
+        identidad, la crítica social y el deseo de conexión, navegando las complejidades de la vida
+        contemporánea con una narrativa intensa y reflexiva.
+        <br><br>
+        Influenciada por el post-hardcore, el metalcore y el deathcore anglosajón, la banda da sus
+        primeros pasos en la escena local de Buenos Aires en 2014. A principios de 2016 publica
+        <em>Amanecer EP</em>, su primer material de estudio, y en 2020 lanza <em>TRSCNDR</em>
+        ("trascender"), su primer disco largo, con influencias que van del metal al rock, el pop,
+        el trap y el EDM. Actualmente prepara su nuevo trabajo,
         <strong>Mitos de un Futuro Cercano</strong>.
+        <br><br>
+        La agrupación está integrada por Juanma Albarracín (voz), Démian Zapiola (guitarra y voz),
+        Nelo Fernández (guitarra y voz), Damián Bonesi (batería) y Poli Abdusetir (bajo y voz).
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Cambios

- **Escuchar álbum** (hero) → ahora linkea directo a Spotify en lugar de `album.html`
- **Experiencias**: quita la card "Reproducir álbum"
- **Show 2 Mayo**: venue actualizado a La Tangente, CABA, Argentina
- **Show 24 Mayo**: nuevo card — Niceto Club, CABA — botón "Entradas" abre WhatsApp a +54 9 11 2456-4111
- **Bio**: texto completo con historia de la banda, influencias e integrantes actuales

https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es7dFu2GpcxcBJwBdhctmL)_