### PR TITLE
fix: update nomios chat URL to Vercel

### DIFF
--- a/n0m10s/index.html
+++ b/n0m10s/index.html
@@ -721,7 +721,7 @@
 		loginNameEl.addEventListener('keydown', (e) => { if (e.key === 'Enter') doLogin(); });
 		loginEmailEl.addEventListener('keydown', (e) => { if (e.key === 'Enter') doLogin(); });
 		// --- Terminal & Nomios API ---
-		const NOMIOS_CHAT = 'https://nomios.duckdns.org/chat';
+		const NOMIOS_CHAT = 'https://nomios-ai-jmalbarras-projects.vercel.app/chat';
 		const output = document.getElementById('terminal-output');
 		const inputEl = document.getElementById('terminal-input');
 		// Android: scroll input arriba del teclado cuando se abre


### PR DESCRIPTION
Cambia la URL de la API de nomios del dominio DuckDNS (cert SSL pendiente) al dominio de Vercel que ya funciona.

- Antes: `https://nomios.duckdns.org/chat`
- Después: `https://nomios-ai-jmalbarras-projects.vercel.app/chat`

Cuando el cert de `nomios.duckdns.org` esté listo se puede revertir al dominio propio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)